### PR TITLE
cblgh/features: add fix_port command

### DIFF
--- a/.datignore
+++ b/.datignore
@@ -1,0 +1,3 @@
+*.sw[op]
+.DS*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+media/content
+.DS*
+*.sw[op]
+media/content/icon.svg
+links/custom.css
+dat.json
+portal.json
+.idea

--- a/rotonde.js
+++ b/rotonde.js
@@ -100,6 +100,11 @@ function Rotonde(client_url)
 
     try {
       portal_data = JSON.parse(portal_str);      
+      // append slash to port entry so that .indexOf works correctly in other parts
+      portal_data.port = portal_data.port.map(function(portal_entry) {
+        if (portal_entry.slice(-1) !== "/") { portal_entry += "/";}
+        return portal_entry
+      })
     } catch (err) {
       console.error("Malformed JSON in portal.json")
     }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -83,6 +83,11 @@ function Feed(feed_urls)
     return archive.readFile('portal.json')
       .then((portal_data) => {
         var portal = JSON.parse(portal_data);
+        // append slash to port entry so that .indexOf works correctly in other parts (e.g ~runes)
+        portal.port = portal.port.map(function(portal_entry) {
+          if (portal_entry.slice(-1) !== "/") { portal_entry += "/";}
+          return portal_entry
+        })
         this.portals[portal.name] = portal;
         return portal.feed
           .filter((entry) => {
@@ -98,7 +103,10 @@ function Feed(feed_urls)
               seed: portal.port.indexOf(r.portal.data.dat) > -1
             })
           ))
-      });
+      })
+      .catch((e) => {
+          console.error("Error reading remote portal.json; malformed json?", e);
+      })
   }
 
   this.debounced_sort_refresh = debounce(function(entries)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -143,15 +143,19 @@ function Operator(el)
     // append slash if not there
     if(path.slice(-1) !== "/") { path += "/" }
     if(r.portal.data.dat == path){ return; }
+    // resolve dns shortnames to their actual dat:// URIs
+    DatArchive.resolveName(path).then(function(result) {
+        path = result
 
-    // Remove
-    if(r.portal.data.port.indexOf(path) == -1){
-      r.portal.data.port.push(path);
-    }
+        // Remove
+        if(r.portal.data.port.indexOf(path) == -1){
+          r.portal.data.port.push(path);
+        }
 
-    r.portal.save();
-    r.portal.update();
-    r.feed.update();
+        r.portal.save();
+        r.portal.update();
+        r.feed.update();
+    }).catch(function(e) { console.error("Error when resolving added portal in operator.js", e) })
   }
 
   this.commands.delete = function(p,option)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -140,12 +140,10 @@ function Operator(el)
   this.commands.dat = function(p,option)
   {
     var path = "dat:"+option;
-    // append slash if not there
-    if(path.slice(-1) !== "/") { path += "/" }
     if(r.portal.data.dat == path){ return; }
     // resolve dns shortnames to their actual dat:// URIs
     DatArchive.resolveName(path).then(function(result) {
-        path = result
+        path = "dat://" + result + "/";
 
         // Remove
         if(r.portal.data.port.indexOf(path) == -1){

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -140,6 +140,8 @@ function Operator(el)
   this.commands.dat = function(p,option)
   {
     var path = "dat:"+option;
+    // append slash if not there
+    if(path.slice(-1) !== "/") { path += "/" }
     if(r.portal.data.dat == path){ return; }
 
     // Remove

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -156,6 +156,27 @@ function Operator(el)
     }).catch(function(e) { console.error("Error when resolving added portal in operator.js", e) })
   }
 
+    this.commands.fix_port = function() {
+        var promises = r.portal.data.port.map(function(portal) {
+            return new Promise(function(resolve, reject) {
+                console.log("first promise")
+                if(portal.slice(-1) !== "/") { portal += "/" }
+                if(r.portal.data.dat == portal){ return; }
+                // resolve dns shortnames to their actual dat:// URIs
+                DatArchive.resolveName(portal).then(function(result) {
+                    result = "dat://" + result + "/";
+                    resolve(result);
+                }).catch(function(e) { console.error("Error when resolving in fix_port:operator.js", e, portal); resolve(portal) })
+            })
+        })
+        Promise.all(promises).then(function(fixed_ports) {
+            r.portal.data.port = fixed_ports;
+            r.portal.save();
+        }).catch(function(e) {
+            console.error("Error when fixing ports; probably offline or malformed json", e)
+        })
+    }
+
   this.commands.delete = function(p,option)
   {
     r.portal.data.feed.splice(option, 1)


### PR DESCRIPTION
this command goes through the port array and resolves all dns shortnames
(e.g. dat://rotonde-beaker-cblgh.hashbase.io) to their actual hashes
(dat://7f2ef715c36b6cd226102192ba220c73384c32e4beb49601fb3f5bba4719e0c5/)

it also adds trailing slashes if they didn't exist

if you do this then you'll fix rune issues stemming from old follows where you used a hashbase address