### PR TITLE
fixed single-quotes inside edited posts

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -36,7 +36,7 @@ function Entry(data)
 
     html += "<t class='portal'><a href='"+this.dat+"'>"+(this.seed ? "@" : "~")+this.portal+"</a> "+this.rune()+" "+(this.target ? "<a href='"+this.target+"'>"+portal_from_hash(this.target.toString())+"</a>" : "")+"</t>";
 
-    var operation = this.portal == r.portal.data.name ? 'edit:'+this.id+' '+this.message.replace("'","") : "quote:"+this.portal+"-"+this.id+" ";
+    var operation = this.portal == r.portal.data.name ? 'edit:'+this.id+' '+this.message.replace(/\'/g,"&apos;") : "quote:"+this.portal+"-"+this.id+" ";
 
     html += this.editstamp ? "<c class='editstamp' data-operation='"+operation+"'>edited "+timeSince(this.editstamp)+" ago</c>" : "<c class='timestamp' data-operation='"+operation+"'>"+timeSince(this.timestamp)+" ago</c>";
 


### PR DESCRIPTION
When a user tries to edit a post containing single-quote characters, everything after the first quote is cut off in the input box. This fixes that issue.