### PR TITLE
 properly fixed URLs in portal list 

### DIFF
--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -86,7 +86,6 @@ function Feed(feed_urls)
     .then(values => {
         var portal = JSON.parse(values[0]);
         var url = "dat://"+values[1];
-        console.log(url);
         // append slash to port entry so that .indexOf works correctly in other parts (e.g ~runes)
         portal.port = portal.port.map(function(portal_entry) {
           if (portal_entry.slice(-1) !== "/") { portal_entry += "/";}

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -5,8 +5,8 @@ function Feed(feed_urls)
 
   this.archives = [];
   this.portals = {};
+  this.urls = {};
   this.filter = "";
-  this.dats = {};
 
   this.install = function(el)
   {
@@ -64,17 +64,17 @@ function Feed(feed_urls)
     var feed_html = "";
     for(name in r.feed.portals){
       var portal = r.feed.portals[name];
-      var dat = r.feed.dats[name];
+      var url = r.feed.urls[name];
       var last_entry = portal.feed[portal.feed.length-1];
       var is_active = last_entry ? Math.floor((new Date() - last_entry.timestamp) / 1000) : 999999;
       var rune = portal.port.indexOf(r.portal.data.dat) > -1 ? "@" : "~";
 
       if(!last_entry){ continue; }
       if(is_active > 190000 && portal.name != r.portal.data.name){
-        feed_html += "<ln title='"+(timeSince(last_entry.timestamp))+"' class='dead' data-operation='un"+dat.url+"'>"+rune+""+portal.name+"</ln>";
+        feed_html += "<ln title='"+(timeSince(last_entry.timestamp))+"' class='dead' data-operation='un"+url+"'>"+rune+""+portal.name+"</ln>";
       }
       else{
-        feed_html+= "<ln title='"+(timeSince(last_entry.timestamp))+"' class='"+(is_active < 150000 ? "active" : "inactive")+"'><a href='"+dat.url+"'>"+rune+""+portal.name+"</a></ln>";
+        feed_html+= "<ln title='"+(timeSince(last_entry.timestamp))+"' class='"+(is_active < 150000 ? "active" : "inactive")+"'><a href='"+url+"'>"+rune+""+portal.name+"</a></ln>";
       }
     }
     return feed_html;
@@ -82,17 +82,18 @@ function Feed(feed_urls)
 
   this.get_feed = function(archive)
   {
-    return Promise.all([archive.readFile('portal.json'), archive.readFile('dat.json')])
+    return Promise.all([archive.readFile('portal.json'), DatArchive.resolveName(archive.url)])
     .then(values => {
         var portal = JSON.parse(values[0]);
-        var dat = JSON.parse(values[1]);
+        var url = "dat://"+values[1];
+        console.log(url);
         // append slash to port entry so that .indexOf works correctly in other parts (e.g ~runes)
         portal.port = portal.port.map(function(portal_entry) {
           if (portal_entry.slice(-1) !== "/") { portal_entry += "/";}
           return portal_entry
         })
         this.portals[portal.name] = portal;
-        this.dats[portal.name] = dat;
+        this.urls[portal.name] = url;
         return portal.feed
           .filter((entry) => {
             if (!this.filter) return true;


### PR DESCRIPTION
Turns out the URLs reported by dat.json also weren't always accurate either, so instead we have to use DatArchive.resolveName() to get the Definitely Correct URL.