### PR TITLE
Fix rotonde to reference window instead of global for jest

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -154,4 +154,4 @@ function Rotonde(client_url)
 }
 
 // Make this accessible for jest
-global.Rotonde = Rotonde;
+window.Rotonde = Rotonde;

--- a/rotonde.spec.js
+++ b/rotonde.spec.js
@@ -14,7 +14,7 @@ global.console.error = jest.fn();
 
 describe("Rotonde", () => {
   beforeEach(() => {
-    rotonde = new global.Rotonde(mockClientUrl);
+    rotonde = new window.Rotonde(mockClientUrl);
     global.r = rotonde;
   });
 


### PR DESCRIPTION
Was throwing a `global is undefined` error in the browser.

(Turns out I wasn't actually using my local version of `rotonde-client` to view my portal so didn't spot the error!)