### PR TITLE
Add an "Index" object to track remote portals

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -4,7 +4,7 @@ function Rotonde(client_url)
 
   // SETUP
 
-  this.requirements = {style:["reset","fonts","main"],script:["portal","feed","entry","operator"]};
+  this.requirements = {style:["reset","fonts","main"],script:["portal","feed","entry","operator","index"]};
   this.includes = {script:[]};
 
   this.install = function()
@@ -68,6 +68,7 @@ function Rotonde(client_url)
   this.portal = null;
   this.feed = null;
   this.operator = null;
+  this.index = null;
 
   this.start = function()
   {
@@ -75,6 +76,7 @@ function Rotonde(client_url)
     document.body.appendChild(this.el);
     document.addEventListener('mousedown',r.mouse_down, false);
 
+    this.index = new Index();
     this.operator = new Operator();
     this.operator.install(this.el);
     this.load_account();
@@ -127,6 +129,7 @@ function Rotonde(client_url)
   this.load_feed = async function(feed)
   {
     this.feed = new Feed(feed);
+    this.index.listeners.push(this.feed);
     this.feed.install(this.el);
   }
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -142,9 +142,10 @@ function Entry(data)
     for(id in words){
       var word = words[id];
       var name_match = r.operator.name_pattern.exec(word)
-      if(name_match && r.feed.portals[name_match[1]]){
-        var remnants = word.substr(name_match[0].length)
-        n.push("<a href='"+r.feed.portals[name_match[1]].dat+"' class='known_portal'>"+name_match[0]+"</a>"+remnants);
+      var portals = name_match ? r.index.lookup_name(name_match[1]) : [];
+      if(portals.length > 0){
+        var remnants = word.substr(name_match[0].length);
+        n.push("<a href='"+portals[0].dat+"' class='known_portal'>"+name_match[0]+"</a>"+remnants);
       }
       else{
         n.push(word)

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -3,67 +3,40 @@ function Feed(feed_urls)
   this.feed_urls = feed_urls;
   this.el = document.createElement('div'); this.el.id = "feed";
 
-  this.archives = [];
-  this.portals = {};
   this.urls = {};
   this.filter = "";
 
   this.install = function(el)
   {
     el.appendChild(this.el);
-
-    this.el.innerHTML = "Fetching "+this.feed_urls.length+" feeds..";
-
-    for(id in this.feed_urls){
-      var archive = new DatArchive(this.feed_urls[id]);
-      var fileEvents = archive.createFileActivityStream();
-      fileEvents.addEventListener('changed', e => {
-        console.log("Automated update")
-        r.feed.update();
-      });
-      archive.gateway = this.feed_urls[id];
-      this.archives.push(archive);
-    }
-    this.archives.push(r.portal.archive);
-
     this.update();
   }
 
-  this.update = async function()
-  {
-    this.get_entries();
-    setTimeout(function(){ r.portal.port_list_el.innerHTML = r.feed.get_feed_html(); }, 1000);
-  }
-
-  this.get_entries = function()
-  {
-    var entries = [];
-    var online_ports_count = 0;
-
-    var archive_promises = this.archives.map((archive) => (
-      this.get_feed(archive)
-        .then((feed_entries) => {
-          online_ports_count += 1;
-          entries = entries.concat(feed_entries);
-          this.debounced_sort_refresh(entries);
-        })
-        .catch((e) => {
-          console.warn(`Unable to fetch, this feed appears to be offline: ${archive.url}`);
-        })
-    ));
-
-    Promise.all(archive_promises).then(() => {
-      console.log("DONE")
-      // Finished attempting to load all ports, maybe do something here?
-    });
-  }
-
-  this.get_feed_html = function()
+  this.refresh = function()
   {
     var feed_html = "";
-    for(name in r.feed.portals){
-      var portal = r.feed.portals[name];
-      var url = r.feed.urls[name];
+    var entries = [];
+    var portals = [];
+    for(id in feed_urls){
+      var portal = r.index.lookup_url(feed_urls[id]);
+      if(!portal) { continue; }
+      portals.push(portal);
+      entries = entries.concat(this.entries_for_portal(portal));
+    }
+    if(entries.length === 0){
+      this.el.innerHTML = "Fetching "+this.feed_urls.length+" feeds..";
+      return;
+    }
+    var owner_portal = r.index.make_portal(r.portal.data, r.portal.data.dat, r.portal.archive);
+    portals.push(owner_portal);
+    entries = entries.concat(this.entries_for_portal(owner_portal));
+    var sorted_entries = entries.sort(function (a, b) {
+      return a.timestamp < b.timestamp ? 1 : -1;
+    });
+
+    for(id in portals) {
+      var portal = portals[id];
+      var url = portal.url;
       var last_entry = portal.feed[portal.feed.length-1];
       var is_active = last_entry ? Math.floor((new Date() - last_entry.timestamp) / 1000) : 999999;
       var rune = portal.port.indexOf(r.portal.data.dat) > -1 || portal.dat === r.portal.data.dat ? "@" : "~";
@@ -76,69 +49,49 @@ function Feed(feed_urls)
         feed_html+= "<ln title='"+(timeSince(last_entry.timestamp))+"' class='"+(is_active < 150000 ? "active" : "inactive")+"'><a href='"+url+"'>"+rune+""+portal.name+"</a></ln>";
       }
     }
-    return feed_html;
-  }
-
-  this.get_feed = async function(archive)
-  {
-    return Promise.all([await archive.readFile('portal.json'), DatArchive.resolveName(archive.url)])
-    .then(values => {
-        var portal = JSON.parse(values[0]);
-        var url = "dat://"+values[1];
-        // append slash to port entry so that .indexOf works correctly in other parts (e.g ~runes)
-        portal.port = portal.port.map(function(portal_entry) {
-          if (portal_entry.slice(-1) !== "/") { portal_entry += "/";}
-          return portal_entry
-        })
-        this.portals[portal.name] = portal;
-        this.urls[portal.name] = url;
-        return portal.feed
-          .filter((entry) => {
-            if (!this.filter) return true;
-            if ("@"+portal.name === this.filter) return true;
-            return entry.message.toLowerCase().includes(this.filter.toLowerCase());
-          })
-          .map((entry, entry_id) => new Entry(
-            Object.assign({}, entry, {
-              portal: portal.name,
-              dat: archive.url,
-              id: entry_id,
-              seed: portal.port.indexOf(r.portal.data.dat) > -1 || portal.dat === r.portal.data.dat
-            })
-          ))
-      })
-      .catch((e) => {
-        console.error("Error reading remote portal.json; malformed json?", e);
-      })
-  }
-
-  this.debounced_sort_refresh = debounce(function(entries)
-  {
-    // Sort
-    var sorted_entries = entries.sort(function (a, b) {
-      return a.timestamp < b.timestamp ? -1 : 1;
-    });
-
-    this.refresh(sorted_entries.reverse());
-  }, 1000, false);
-
-  this.refresh = function(entries)
-  {
-    console.log("Refresh!")
+    r.portal.port_list_el.innerHTML = feed_html;
 
     var html = this.filter ? "<c class='clear_filter' data-operation='clear_filter'>Filtering by "+this.filter+"</c>" : "";
     var c = 0;
-    for(id in entries){
-      var entry = entries[id];
+    for(id in sorted_entries){
+      var entry = sorted_entries[id];
       if(!entry || entry.timestamp > new Date()) { continue; }
       if(!entry.is_visible()){ continue; }
       html += entry.to_html();
       if(c > 40){ break; }
       c += 1;
     }
-
     html += "<div class='entry'><t class='portal'>$rotonde</t><t class='timestamp'>Just now</t><hr/><t class='message' style='font-style:italic'>Welcome to #rotonde, a decentralized social network. Share your dat:// url with others and add theirs into the input bar to get started.</t></div>"
     this.el.innerHTML = html;
+  }
+
+  this.entries_for_portal = function(portal)
+  {
+    return portal.feed
+      .filter((entry) => {
+        if (!this.filter) return true;
+        if ("@"+portal.name === this.filter) return true;
+        return entry.message.toLowerCase().includes(this.filter.toLowerCase());
+      }).map((entry, entry_id) => new Entry(
+        Object.assign({}, entry, {
+          portal: portal.name,
+          dat: portal.archive.url,
+          id: entry_id,
+          seed: portal.port.indexOf(r.portal.data.dat) > -1 || portal.dat === r.portal.data.dat
+        })
+      ));
+  }
+
+  this.debounced_refresh = debounce(() => this.refresh(), 1000, false);
+
+  this.update = function()
+  {
+    this.refresh();
+  }
+
+  this.portal_changed = function(key)
+  {
+    this.debounced_refresh();
   }
 }
 
@@ -162,12 +115,8 @@ function debounce(func, wait, immediate)
 
 function portal_from_hash(hash)
 {
-  for(name in r.feed.portals){
-    var portal = r.feed.portals[name];
-    if(r.feed.portals[name].dat == hash){
-      return "@"+portal.name;
-    }
-  }
+  var portal = r.index.lookup_url(hash);
+  if(portal){ return "@"+portal.name; }
   return hash.substr(0,12)+".."+hash.substr(hash.length-3,2);
 }
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,0 +1,100 @@
+function Index()
+{
+  this.portals = {};
+  this.fetching_portals = {};
+
+  this.listeners = [];
+
+  this.portal_file_name = 'portal.json';
+
+  this.lookup_url = function(url)
+  {
+    var portal = this.portals[url];
+    if(typeof portal === 'undefined'){
+      if(!this.fetching_portals[url]){
+        this.fetching_portals[url] = true;
+        this.fetch_url(url);
+      }
+      return null;
+    }
+    return portal;
+  }
+
+  this.lookup_name = function(name)
+  {
+    // We return an array since multiple people might be using the same name.
+    var results = [];
+    for(var url in this.portals){
+      var portal = this.portals[url];
+      if(portal.name === name){ results.push(portal); }
+    }
+    return results;
+  }
+
+  this.autocomplete_name = function(name)
+  {
+    var results = [];
+    name = name.replace("@","").replace("@","").trim();
+    for(var url in this.portals){
+      var portal = this.portals[url];
+      if(portal.name && portal.name.substr(0,name.length) == name){
+        results.push(portal);
+      }
+    }
+    return results;
+  }
+
+  this.fetch_url = async function(url)
+  {
+    var resolved = url;
+    // Normalize dat:// URLs to their public key.
+    if(url.slice(0,6) === 'dat://'){
+      try{
+        resolved = 'dat://' + await DatArchive.resolveName(url) + '/';
+      }catch(e){
+        console.error("Couldn't resolve dat:// URL.", e);
+      }
+    }
+    var archive = new DatArchive(resolved);
+    var activity = archive.createFileActivityStream(this.portal_file_name);
+    this.read_portal_json(url, resolved, archive);
+    activity.addEventListener('changed', e => {
+      this.read_portal_json(url, resolved, archive);
+    });
+  }
+
+  this.make_portal = function(data, url, archive)
+  {
+    return Object.assign({}, data, {
+      port: data.port.map(entry => {
+        // Normalize dat:// entries to include a trailing slash.
+        if(entry.slice(0,6) === 'dat://' && entry.slice(-1) !== '/') {
+          entry += '/';
+        }
+        return entry;
+      }),
+      url: url,
+      archive: archive
+    });
+  }
+
+  this.read_portal_json = async function(key, url, archive)
+  {
+    try{
+      var portal_data = await archive.readFile(this.portal_file_name);
+      var portal = JSON.parse(portal_data);
+      delete this.fetching_portals[key];
+      this.portals[key] = this.make_portal(portal, url, archive);
+      this.notify_change(key);
+    }catch(e){
+      console.error("Error reading remote portal.json; malformed json?", e);
+    }
+  }
+
+  this.notify_change = function(key)
+  {
+    for(var id in this.listeners){ this.listeners[id].portal_changed(key); }
+  }
+}
+
+r.confirm("script","index");


### PR DESCRIPTION
Right now, Rotonde queries remote portals in an ad hoc way, mostly
leaving it up to Feed to fetch and store them.  This makes it hard to
show portals outside the ones you're following.  In particular, re-
entries and replies to someone outside your list of portals show up as
raw dat:// URLs.

This patch introduces an "Index" singleton which fetches and stores
remote portals.  You can query them by URL, by name, or using name auto-
complete logic which has been moved from the Operator class.  Instead of
accessing Feed's data structures directly, we ask the Index whenever we
want to get a remote portal.  The Index will return the portal if it has
it, and go fetch it otherwise.

At the same time, simplify Feed so all rendering happens in a single
method.  Index notifies Feed to re-render by calling portal_changed.

With this change, re-entries and replies show the proper name: they call
portal_from_hash, which calls index.lookup_url, which will perform the
lookup if necessary.