### PR TITLE
Escape file names to accommodate valid characters

### DIFF
--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -71,7 +71,8 @@ function Operator(el)
     if(message == ""){ return; }
     // Rich content
     if(message.indexOf(" >> ") > -1){
-      media = message.split(" >> ")[1].split(" ")[0].trim();
+      // encode the file names to allow for odd characters, like spaces
+      media = encodeURIComponent(message.split(" >> ")[1].trim());
       message = message.split(" >> ")[0].trim();
     }
 


### PR DESCRIPTION
Fixes #53

I tested this pretty extensively (in the manual, and drag and drop cases), but I'm not quite sure what the intent of the removed `split` was. If there is something I missed there, please let me know!