### PR TITLE
visitors filter by portalname + validate clear_filter immediately upon injection

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -144,6 +144,8 @@ function Rotonde(client_url)
     e.preventDefault();
     r.operator.inject(e.target.getAttribute("data-operation"));
     window.scrollTo(0, 0);
+    if(!e.target.getAttribute("validate")){ return; }
+    r.operator.validate();
   }
 
   this.reset = function()

--- a/rotonde.js
+++ b/rotonde.js
@@ -118,6 +118,8 @@ function Rotonde(client_url)
 
     if(!info.isOwner){
       this.operator.el.style.display = "none";
+      this.feed.filter = "@" + this.portal.data.name;
+      this.feed.update();
     }
   }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -51,7 +51,7 @@ function Feed(feed_urls)
     }
     r.portal.port_list_el.innerHTML = feed_html;
 
-    var html = this.filter ? "<c class='clear_filter' data-operation='clear_filter'>Filtering by "+this.filter+"</c>" : "";
+    var html = this.filter ? "<c class='clear_filter' data-operation='clear_filter' validate='validate'>Filtering by "+this.filter+"</c>" : "";
     var c = 0;
     for(id in sorted_entries){
       var entry = sorted_entries[id];


### PR DESCRIPTION
currently, when you visit another user's Rotonde page, you see their feed much like they would see it. This sometimes makes it difficult to see what they themselves have posted. this PR changes this, so that by default the feed is filtered for their @name if you are not the owner of the page.
to make it possible to still see their full feed (including posts by others that don't mention them) if one so desires, I made it so that filters get removed immediately upon clicking the "filtering by …" message. feel free to change this behavior if you have a better solution.