### PR TITLE
Fix formatting across line-breaks

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -81,15 +81,16 @@ function Entry(data)
 
   this.formatter = function(message)
   {
-    var m = message;
+    return message.split(/\r\n|\n/).map(this.format_line, this).join("<br>");
+  }
 
+  this.format_line = function(m)
+  {
     m = this.escape_html(m);
     m = this.format_links(m);
     m = this.highlight_portal(m);
     m = this.link_portals(m);
     m = this.format_style(m);
-    m = this.format_newlines(m);
-
     return m;
   }
 
@@ -166,11 +167,6 @@ function Entry(data)
       m = m.replace('{_',"<i>").replace('_}',"</i>");
     }
     return m
-  }
-
-  this.format_newlines = function(m)
-  {
-    return m.replace(/\r\n|\n/g,"<br>");
   }
 
   this.time_ago = function()


### PR DESCRIPTION
Changes the formatter to operate on individual lines. This fixes issues where newlines are treated as part of a 'word'. For example, in the following post:

    http://example.com/

    hello world

...the second line would appear as:

> [**hello..**](http://example.com/hello) world