### PR TITLE
Add "install://" links to support the spread of decentralized clients

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,0 +1,18 @@
+(async function(){
+  var hash = await DatArchive.resolveName(document.currentScript.src);
+  var index_html = "";
+  index_html += "<!doctype html>\n";
+  index_html += "<html>\n";
+  index_html += "  <head>\n";
+  index_html += "    <script src='dat://" + hash + "/rotonde.js'></script>\n";
+  index_html += "  </head>\n";
+  index_html += "  <body></body>\n";
+  index_html += "  <script>\n";
+  index_html += "    var r = new Rotonde('dat://" + hash + "/'); r.install();\n";
+  index_html += "  </script>\n";
+  index_html += "</html>\n";
+  var archive = new DatArchive(window.location.toString());
+  await archive.writeFile("/index.html", index_html);
+  await archive.commit();
+  window.location.reload();
+})();

--- a/links/main.css
+++ b/links/main.css
@@ -52,6 +52,7 @@ body #feed .entry .timestamp:hover { cursor:pointer; text-decoration: underline;
 body #feed .entry .editstamp { color:#aaa; font-size:11px; }
 body #feed .entry .editstamp:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
+body #feed .entry .install:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .media { max-width: 100%; margin-top:15px; display:block; margin-bottom:15px; border-radius:4px; }
 body #feed .entry .tools { display:none; float:right; margin-right:15px; margin-top:10px; cursor:pointer; }
 body #feed .entry .tools > *:hover { text-decoration: underline; }

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -120,6 +120,10 @@ function Entry(data)
         var compressed = word.substr(0,12)+".."+word.substr(word.length-3,2);
         n.push("<a href='"+word+"'>"+compressed+"</a>");
       }
+      else if(word.substr(0,10) == "install://"){
+        var compressed = word.substr(0,16)+".."+word.substr(word.length-3,2);
+        n.push("<c class='install' data-operation='"+word+"'>["+compressed+"]</c>");
+      }
       else if(word.substr(0,1) == "#"){
         n.push("<c class='hashtag' data-operation='filter "+word+"'>"+word+"</c>");
       }

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -159,6 +159,17 @@ function Operator(el)
     }).catch(function(e) { console.error("Error when resolving added portal in operator.js", e) })
   }
 
+  this.commands.install = async function(p,option)
+  {
+    var path = "dat:"+option;
+    if(!window.confirm("You're sure you want to install this?")){ return; }
+    DatArchive.resolveName(path).then(function(result) {
+      var s = document.createElement("script");
+      s.src = "dat://" + result + "/install.js";
+      document.getElementsByTagName("head")[0].appendChild(s);
+    });
+  }
+
   this.commands.fix_port = function() {
       var promises = r.portal.data.port.map(function(portal) {
           return new Promise(function(resolve, reject) {

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -61,6 +61,7 @@ function Operator(el)
   {
     this.input_el.value = text;
     this.input_el.focus();
+    this.update();
   }
 
   this.commands = {};
@@ -296,7 +297,6 @@ function Operator(el)
         if (autocomplete.length > 0) {
           words[words.length - 1] = "@" + autocomplete[0].name;
           r.operator.inject(words.join(" ")+" ");
-          r.operator.update();
           return;
         }
       }


### PR DESCRIPTION
So, we've been seeing a lot of feature discussion in GitHub issues, which is great!  But why should feature development need to go through GitHub at all?  Rotonde is decentralized: you can implement the features you want and use them right away.

The problem is, even if you implement a set of features, nobody else will use them unless they're convenient to install.  So, let's add "install://" links!  When you enter an "install://" link in the operator field, Rotonde looks for an "install.js" file in the corresponding dat:// archive and runs it.

The Rotonde client comes with an install.js script which replaces the user's index.html, updating the scripts to point to the newly-installed client.  This makes it easy to install a new client just by linking it to somebody.  We highlight install links in the feed so you can click them and install things even more easily.

Running arbitrary JavaScript would be a pretty big security problem on the normal web, but in Rotonde the damage is limited to your own portal, and you can always roll things back.  I think this could be an interesting experiment.  Let me know what you think!