### PR TITLE
Initial proposal for multiple mentions

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -21,7 +21,10 @@ function Entry(data,host)
 
   this.to_html = function()
   {
-    this.is_mention = this.target && r.home.portal.url && to_hash(this.target) == to_hash(r.home.portal.url);
+    this.is_mention = this.target && r.home.portal.url;
+    for(i in this.target){
+      this.is_mention = this.is_mention && to_hash(this.target[i]) == to_hash(r.home.portal.url);
+    }
 
     var html = "";
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -21,9 +21,12 @@ function Entry(data,host)
 
   this.to_html = function()
   {
-    this.is_mention = this.target && r.home.portal.url;
+    this.is_mention = false;
     for(i in this.target){
-      this.is_mention = this.is_mention && to_hash(this.target[i]) == to_hash(r.home.portal.url);
+      if(to_hash(this.target[i]) == to_hash(r.home.portal.url)){
+        console.log("we got mentioned!");
+        this.is_mention = true;
+      }
     }
 
     var html = "";

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -140,7 +140,6 @@ function Feed(feed_urls)
           var index = parseInt(tmp[1]);
           // find address
           var name = null;
-          // spaghetti
           if(to_hash(entry.target[index]) == to_hash(r.home.portal.url)){
             name = r.home.portal.json.name;
           }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -132,42 +132,20 @@ function Feed(feed_urls)
         legacy = true;
       }
 
-      // lookup dat addresses -- CACHE THIS SOMEHOW!
-      if(!legacy){
-        var exp = /@([0-9]+)/g;
-        var tmp;
-        while((tmp = exp.exec(entry.message)) !== null){
-          var index = parseInt(tmp[1]);
-          // find address
-          var name = null;
-          if(to_hash(entry.target[index]) == to_hash(r.home.portal.url)){
-            name = r.home.portal.json.name;
-          }
-          else{
-            for(i in r.home.feed.portals){
-              if(r.home.feed.portals[i].url == entry.target[index]){
-                name = r.home.feed.portals[i].json.name;
-                break;
-              }
-            }
-          }
-          if(name !== null){
-            entry.message = entry.message.replace(tmp[0], "@" + name);
-          }
-        }
-      }
-
-
       if(!entry || entry.timestamp > new Date()) { continue; }
-      // check that this function works as expected
       if(!entry.is_visible(r.home.feed.filter,r.home.feed.target)){ continue; }
-      if(entry.message.toLowerCase().indexOf(r.home.portal.json.name) > -1){
+      if(legacy && entry.message.toLowerCase().indexOf(r.home.portal.json.name) > -1){
         // backwards-compatible mention
         mentions += 1;
       }
-      if(entry.target.includes(r.home.portal.url.trim())){
-        // new-style mentions
-        mentions += 1;
+      if(!legacy){
+        // multiple-mention
+        for(i in entry.target){
+          if(to_hash(entry.target[i]) == to_hash(r.home.portal.url)){
+            mentions += 1;
+            break;
+          }
+        }
       }
       feed_html += entry.to_html();
       if(c > 40){ break; }

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -102,26 +102,21 @@ function Operator(el)
       message = message.split(" >> ")[0].trim();
     }
 
-    var data = {media:"", message:"", timestamp:Date.now(), target:[]};
+    var data = {media:"", message:message, timestamp:Date.now(), target:[]};
     if(media){
       data.media = media;
     }
     // handle mentions
-    var finalmsg = message;
-    var exp = /@(\w+)/g;
+    var exp = /([@~])(\w+)/g;
     var tmp;
-    var counter = 0;
     while((tmp = exp.exec(message)) !== null){
-      var name = tmp[1];
-      finalmsg = finalmsg.replace(tmp[1], counter.toString());
-      counter++;
-
-      var portals = r.operator.lookup_name(tmp[1]);
+      var portals = r.operator.lookup_name(tmp[2]);
       if(portals.length > 0){
         data.target.push(portals[0].url);
+      }else{
+        data.target.push("");
       }
     }
-    data.message = finalmsg;
 
     r.home.add_entry(new Entry(data));
     setTimeout(r.home.feed.refresh, 250);
@@ -202,7 +197,7 @@ function Operator(el)
     r.home.feed.el.className = option;
 
     if(p){
-      setTimeout(r.home.feed.refresh, 250);  
+      setTimeout(r.home.feed.refresh, 250);
     }
   }
 
@@ -319,7 +314,7 @@ function Operator(el)
 
     if(e.key == "ArrowUp"){
       if(r.operator.cmd_history.length > 0){
-        e.preventDefault();  
+        e.preventDefault();
       }
       if(r.operator.cmd_index == -1){
         r.operator.cmd_index = r.operator.cmd_history.length-1;
@@ -334,7 +329,7 @@ function Operator(el)
     }
     if(e.key == "ArrowDown"){
       if(r.operator.cmd_history.length > 0){
-        e.preventDefault();  
+        e.preventDefault();
       }
       if(r.operator.cmd_index == r.operator.cmd_history.length-1 && r.operator.cmd_history.length > 0){
         r.operator.inject(r.operator.cmd_buffer);

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -88,7 +88,6 @@ function Operator(el)
 
   this.commands = {};
 
-  // catches neauoire from @neauoire
   this.commands.say = function(p)
   {
     var message = p.trim();
@@ -102,20 +101,27 @@ function Operator(el)
       message = message.split(" >> ")[0].trim();
     }
 
-    var data = {message:message,timestamp:Date.now()};
+    var data = {media:"", message:"", timestamp:Date.now(), target:[]};
     if(media){
       data.media = media;
     }
-    // if message starts with an @ symbol, then we're doing a mention
-    if(message.indexOf("@") == 0){
-      var name = message.split(" ")[0]
-      // execute the regex & get the first matching group (i.e. no @, only the name)
-      name = r.operator.name_pattern.exec(name)[1]
-      var portals = r.operator.lookup_name(name);
+    // handle mentions
+    var finalmsg = message;
+    var exp = /@(\w+)/g;
+    var tmp;
+    var counter = 0;
+    while((tmp = exp.exec(message)) !== null){
+      var name = tmp[1];
+      finalmsg = finalmsg.replace(tmp[1], counter.toString());
+      counter++;
+
+      var portals = r.operator.lookup_name(tmp[1]);
       if(portals.length > 0){
-        data.target = portals[0].url;
+        data.target.push(portals[0].url);
       }
     }
+    data.message = finalmsg;
+
     r.home.add_entry(new Entry(data));
     setTimeout(r.home.feed.refresh, 250);
   }
@@ -304,6 +310,7 @@ function Operator(el)
 
     if(e.key == "Tab"){
       e.preventDefault();
+      // TODO: match regex starting at cursor position
 
       var words = r.operator.input_el.value.split(" ");
       var last = words[words.length - 1]


### PR DESCRIPTION
(#73)

Short and simple: messages get scanned for `@user` bits, and Rotonde performs a lookup in the feed. The `target` field in the `portal.json` file becomes an array of mentions in order, and the first mention in the message becomes `@0`, the second `@1`, etc.

When fetching messages using multiple mentions, Rotonde does the reverse: scans for `@[integer]` and fetches the portal URL from the `target` array. It is then substituted by the corresponding username.

Rough around the edges, but backwards compatibility is working, as far as I can see. _Needs lots of testing!_

**Issues:**

1. Messages on the feed are scanned for mentions every single time; we should avoid doing this. Messages could have a `processed` bool or something similar.
2. Mentions to people _not_ in your feed or whose portal we haven't connected to yet results in ugly `@0`,`@1` stuff. It should be more user-friendly.
3. Mentions should be clickable links.