### PR TITLE
Add sticky headers & styling tweaks

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -1,4 +1,4 @@
-body { font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#ddd; padding-bottom: 140px}
+body { font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#f9f9f9; padding-bottom: 140px; width: 100vw; display: flex; flex-direction: column; padding: 0px;}
 t { display:inline-block; }
 hr { clear:both; }
 
@@ -28,7 +28,7 @@ body #portal .port_list ln.dead {color:#ccc;}
 body #portal .port_list ln.dead:hover { text-decoration: underline; cursor: pointer }
 body #portal:hover .port_list { display: block }
 
-body #feed { padding:0px 30px; width:calc(100vw - 420px); min-width: 600px; max-width:700px; margin:0px auto;}
+body #feed { padding:0px; min-width: 600px; max-width:700px; margin:0px auto; width: 100vw;}
 body #feed .clear_filter { margin-bottom: 20px; display: block; margin-left:30px; }
 body #feed .clear_filter:hover { cursor:pointer; text-decoration: underline; }
 body #feed .clear_filter b { font-family: 'input_mono_medium' }
@@ -66,7 +66,7 @@ body #feed .entry a.media:hover { background: #000; color: #fff; }
 body #feed .entry.whisper { background:black; color:white; }
 body #feed .entry.whisper .icon { filter: invert(100%) }
 
-#wr_timeline { display: block }
+#wr_timeline { display: block; padding-bottom: 50px; }
 #wr_portals { display: none; background:white;}
 
 body #feed.mentions .entry { display: none }
@@ -75,38 +75,38 @@ body #feed.mentions .entry.mention { background:#eee; display: block }
 body #feed.mentions #wr_portals { display: block }
 body #feed.mentions #wr_portals { display: none }
 body #feed.portals #wr_portals { display: block }
-body #feed.portals #wr_timeline { display: none }
+body #feed.portals #wr_timeline { display: none; }
 
 #tab_network { background:transparent !important; color:#aaa !important; }
 #tab_network:hover { cursor: default !important; }
 
-body #feed #tabs { z-index: 600;position: relative;}
-body #feed #tabs t { padding:5px 15px; display: inline-block; font-size: 12px; font-weight: bold; color:white;}
+body #feed #tabs { z-index: 600;position: sticky;top: 100px;background: #f9f9f9;}
+body #feed #tabs t { padding:5px 15px; display: inline-block; font-size: 12px; font-weight: bold; color:#aaa;}
 body #feed #tabs #tab_services { float:right; display: none }
 body #feed #tabs t:hover,body #feed #tabs t.active { background:white; color:black; cursor:pointer;}
 
 body #feed #tabs :first-child { background:white; color:black; }
-body #feed.mentions #tabs :first-child { background:transparent; color:white; }
+body #feed.mentions #tabs :first-child { background:transparent; color:#aaa; }
 body #feed.mentions #tab_mentions { background:white; color:black; }
 body #feed.portals #tab_portals { background:white; color:black; }
-body #feed.portals #tabs :first-child { background:transparent; color:white; }
+body #feed.portals #tabs :first-child { background:transparent; color:#aaa; }
 
 body #feed #tabs :first-child:hover { background:white !important; color:black !important; }
 
 .hidden { display: none; }
 
-body #operator { max-width: 700px;position: relative;overflow: hidden;z-index: 500;font-family: "input_mono_regular";margin: 0px auto;margin-top: 100px; margin-bottom:40px; min-width: 400px;}
-body #operator textarea { display: flex; color: white; width: 100%; align-content: center; height: 20px; resize: none; max-height: 100px; background: transparent; align-self: center; transition: all 150ms; line-height: 20px; min-height:20px; color:#000;}
+body #operator { max-width: 700px; position: sticky; overflow: hidden;z-index: 500;font-family: "input_mono_regular";margin: 0px auto;margin-top: 100px; margin-bottom:40px; min-width: 400px; width: 100vw; top: 0px;background: #f9f9f9;z-index: 999;padding-top: 20px;}
+body #operator textarea { display: flex; color: white; width: 100%; align-content: center; height: 20px; resize: none; max-height: 100px; background: transparent; align-self: center; transition: all 150ms; line-height: 22px; min-height:20px; color:#000;padding-left: 15px;}
 body #operator textarea.drag { background: #b7b7b7; }
 body #operator textarea::-webkit-scrollbar { display: none; }
 body #operator #hint { line-height: 20px; display: flex; text-align: right; align-self: flex-end; white-space: nowrap; color:RGBA(0,0,0,0.25); margin-right:15px;}
 body #operator #hint.autocomplete { color:black; }
-body #operator #wrapper { overflow: hidden; min-height: 1em; display: flex; padding: 15px 0px; background: transparent; color: white; font-size: 12px; padding-left:20px; border-bottom: 1px solid #fff;}
+body #operator #wrapper { overflow: hidden; min-height: 1em; display: flex; padding: 15px 0px; background: white; color: white; font-size: 12px; padding-left:20px; border: 1px solid #f1f1f1;}
 body #operator:hover #options { opacity: 1 }
 body #operator #options { padding:5px 15px; font-size:11px; color:#000; height:0px; opacity: 0; transition: opacity 0.25s ease-in-out }
 body #operator #options t:hover { text-decoration: underline; color:black; cursor:pointer; }
 body #operator #options t.right { float:right; display: inline-block; margin-left:10px; }
-body #operator #rune { position: absolute; left:0px; color:#fff; line-height: 16pt;}
+body #operator #rune { position: absolute; left:0px; color:#aaa; line-height: 16pt;padding-left: 15px;}
 
 .badge {     display: inline-block;margin-bottom: 1px;position: relative;padding: 10px;background: white;font-size: 11pt;width: calc(25% - 20px);float: left; text-align: center; height:240px; overflow: hidden;}
 .badge img { width:100px; height: 100px; display:block; margin:20px auto;}


### PR DESCRIPTION
- Added sticky headers to the input box and tabs to keep users oriented when scrolling.
- Small adjustments to let rotonde display better in small sized windows and respond accordingly. 
- Input box styling adjustments help make the input more clear for new users. 

There is currently a bug with the sticky headers due to some event listeners that scroll to top when tabs are clicked.

I can reduce this down to just the headers and width adjustments if you want.