### PR TITLE
Update feed.js

### DIFF
--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -165,7 +165,7 @@ function Feed(feed_urls)
 
 function to_hash(url)
 {
-  return url.replace("dat://","").replace("/","").trim();
+  return url && url.replace("dat://","").replace("/","").trim();
 }
 
 function portal_from_hash(url)


### PR DESCRIPTION
not sure if this is a clean fix, but checking for the url before calling `.replace` should fix what I am seeing:

![image](https://user-images.githubusercontent.com/675259/32412455-5fbc5afe-c1c6-11e7-9566-24d415c2e49c.png)
