### PR TITLE
Escape media and version (prevent XSS); Handle extra versions

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -114,7 +114,7 @@ body #operator #rune { position: absolute; left:0px; color:#aaa; line-height: 16
 .badge a:hover { text-decoration: underline; cursor: pointer; }
 .badge t { font-size:10pt; color:#ccc; line-height: 11pt; margin-top:0px; display: inline-block;}
 .badge span { display: inline-block; font-size:11px; font-weight: bold}
-.badge span.version { background: #eee;padding: 0px 7px;border-radius: 100px;font-size: 11px;font-weight: bold;line-height: 18px;margin-right: 15px; }
+.badge span.version { background: #eee;padding: 0px 7px;border-radius: 9px;font-size: 11px;font-weight: bold;line-height: 18px;margin-right: 15px; }
 .badge span.version.same { background:#72dec2; color:white; }
 .badge span.time_ago { color:#ccc; padding-left:5px; }
 .badge span b { font-weight: bold }

--- a/rotonde.js
+++ b/rotonde.js
@@ -62,6 +62,25 @@ function Rotonde(client_url)
     }
   }
 
+  // Common functions
+
+  this.escape_html = function(m)
+  {
+    return m
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  this.escape_attr = function(m)
+  {
+    // This assumes that all attributes are wrapped in '', never "".
+    return m
+      .replace(/'/g, "&#039;");
+  }
+
   // START
 
   this.el = document.createElement('div');

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -94,6 +94,7 @@ function Entry(data,host)
   {
     var html = "";
     if(this.media){
+      this.media = encodeURI(this.media);
       var parts = this.media.split(".")
       extension = parts[parts.length-1].toLowerCase();
       if (parts.length === 1) {

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -47,11 +47,11 @@ function Entry(data,host)
   {
     var html = ""
 
-    html += "<t class='portal'><a href='"+this.host.url+"'>"+this.host.relationship()+this.host.json.name+"</a> "+this.rune()+" ";
+    html += "<t class='portal'><a href='"+this.host.url+"'>"+this.host.relationship()+r.escape_html(this.host.json.name)+"</a> "+this.rune()+" ";
 
     for(i in this.target){
       if(this.target[i]){
-        html += "<a href='" + this.target[i] + "'>" + portal_from_hash(this.target[i].toString()) + "</a>";
+        html += "<a href='" + r.escape_attr(this.target[i]) + "'>" + r.escape_html(portal_from_hash(this.target[i].toString())) + "</a>";
       }else{
         html += "...";
       }
@@ -60,7 +60,7 @@ function Entry(data,host)
       }
     }
 
-    html += "</t><t class='link' data-operation='filter:"+this.host.json.name+"-"+this.id+"'>•</t>";
+    html += "</t><t class='link' data-operation='filter:"+r.escape_attr(this.host.json.name)+"-"+this.id+"'>•</t>";
 
     var operation = '';
     if(this.host.json.name == r.home.portal.json.name)
@@ -75,7 +75,7 @@ function Entry(data,host)
     var lz = (v)=> { return (v<10 ? '0':'')+v; };
     var localtime = ''+date.getFullYear()+'-'+lz(date.getMonth()+1)+'-'+lz(date.getDate())+' '+lz(date.getHours())+':'+lz(date.getMinutes());
 
-    html += this.editstamp ? "<c class='editstamp' data-operation='"+operation+"' title='"+localtime+"'>edited "+timeSince(this.editstamp)+" ago</c>" : "<c class='timestamp' data-operation='"+operation+"' title='"+localtime+"'>"+timeSince(this.timestamp)+" ago</c>";
+    html += this.editstamp ? "<c class='editstamp' data-operation='"+r.escape_attr(operation)+"' title='"+localtime+"'>edited "+timeSince(this.editstamp)+" ago</c>" : "<c class='timestamp' data-operation='"+operation+"' title='"+localtime+"'>"+timeSince(this.timestamp)+" ago</c>";
 
     html += this.host.json.name == r.home.portal.json.name && r.is_owner ? "<t class='tools'><t data-operation='delete:"+this.id+"'>del</t></t>" : "";
 
@@ -186,7 +186,7 @@ function Entry(data,host)
 
   this.highlight_portal = function(m)
   {
-    return m.replace('@'+r.home.portal.json.name,'<t class="highlight">@'+r.home.portal.json.name+"</t>")
+    return m.replace('@'+r.home.portal.json.name,'<t class="highlight">@'+r.escape_html(r.home.portal.json.name)+"</t>")
   }
 
   this.link_portals = function(m)

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -52,9 +52,9 @@ function Home()
   this.update = function()
   {
     this.icon_el.innerHTML = "<img src='media//content/icon.svg'/>";
-    this.name_el.innerHTML = r.home.portal.json.name;
-    this.site_el.innerHTML = "<a href='"+r.home.portal.json.site+"' target='_blank'>"+r.home.portal.json.site.replace(/^(https?:|)\/\//,'')+"</a>";
-    this.desc_el.innerHTML = r.home.portal.json.desc;
+    this.name_el.innerHTML = r.escape_html(r.home.portal.json.name);
+    this.site_el.innerHTML = "<a href='"+r.escape_attr(r.home.portal.json.site)+"' target='_blank'>"+r.escape_html(r.home.portal.json.site).replace(/^(https?:|)\/\//,'')+"</a>";
+    this.desc_el.innerHTML = r.escape_html(r.home.portal.json.desc);
 
     this.name_el.setAttribute("data-operation",r.home.portal.json.name == "new_name" ? "edit:name "+r.home.portal.json.name : "filter @"+r.home.portal.json.name);
     this.desc_el.setAttribute("data-operation","edit:desc "+r.home.portal.json.desc);

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -124,7 +124,7 @@ function Portal(url)
     var html = "";
 
     html += "<img src='"+this.archive.url+"/media/content/icon.svg'/>";
-    html += "<a data-operation='"+this.url+"' href='"+this.url+"'>"+this.relationship()+this.json.name+"</a> ";
+    html += "<a data-operation='"+this.url+"' href='"+this.url+"'>"+this.relationship()+r.escape_html(this.json.name)+"</a> ";
 
     html += "<br />"
     
@@ -137,14 +137,8 @@ function Portal(url)
     if(this.json.client_version){
       // Used to check if the rotonde version matches when multiple version lines are present.
       var client_version_main = this.json.client_version.split(/\r\n|\n/)[0];
-      // Based off of entry.formatter
-      this.json.client_version = this.json.client_version
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;")
-        .split(/\r\n|\n/).slice(0, 2).join("<br>") // Allow 2 lines for mod versions
+      this.json.client_version = r.escape_html(this.json.client_version)
+        .split(/\r\n|\n/).slice(0, 2).join("<br>"); // Allow 2 lines for mod versions
       html += "<span class='version "+(client_version_main == r.home.portal.json.client_version ? 'same' : '')+"'>"+this.json.client_version+"</span>"
     }
     

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -135,7 +135,17 @@ function Portal(url)
     html += "<br />"
     // Version
     if(this.json.client_version){
-      html += "<span class='version "+(this.json.client_version == r.home.portal.json.client_version ? 'same' : '')+"'>"+this.json.client_version+"</span>"
+      // Used to check if the rotonde version matches when multiple version lines are present.
+      var client_version_main = this.json.client_version.split(/\r\n|\n/)[0];
+      // Based off of entry.formatter
+      this.json.client_version = this.json.client_version
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;")
+        .split(/\r\n|\n/).slice(0, 2).join("<br>") // Allow 2 lines for mod versions
+      html += "<span class='version "+(client_version_main == r.home.portal.json.client_version ? 'same' : '')+"'>"+this.json.client_version+"</span>"
     }
     
     html += "<span>"+this.json.port.length+" Portals</span>"


### PR DESCRIPTION
Rotonde doesn't escape the entry `media`, which allows anyone to hide anything in there.

```json
    {
      "message": "Horrible idea of the day: #rotonde bot that reposts my Twitter timeline / Twitter client that works via #rotonde.",
      "timestamp": 1509975157676,
      "media": "<!--ext' style='display: none'></a><a class='media' href='https://twitter.com/0x0ade/status/927267952721833984' onmouseover='alert(\"XSS.\")'>Twitter</a><!----><a a='.png",
      "target": []
    }
```

![image](https://user-images.githubusercontent.com/1200380/32449765-bd867424-c312-11e7-8b98-081f30443935.png)

Same goes to `client_version`:

```json
"client_version": "0.1.67-dev<br><a href='https://twitter.com/0x0ade'>twttr</a>"
```

![image](https://user-images.githubusercontent.com/1200380/32450116-b4345a3e-c313-11e7-965d-f097841b29cf.png)

This changeset escapes the media URL using `encodeURI` and changes the portal version handling to
1. check the first line for the rotonde version
2. allow a second line to mark any "mod version".

I don't know how "strict" it should be, so I left room for _some_ customization of the client version.

```json
"client_version": "0.1.67\ntonne r0"
```

![image](https://user-images.githubusercontent.com/1200380/32450085-9c8685ba-c313-11e7-9111-94568ac3c290.png)
