### PR TITLE
Badge version check now powered by regex

### DIFF
--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -135,11 +135,19 @@ function Portal(url)
     html += "<br />"
     // Version
     if(this.json.client_version){
-      // Used to check if the rotonde version matches when multiple version lines are present.
-      var client_version_main = this.json.client_version.split(/\r\n|\n/)[0];
-      this.json.client_version = r.escape_html(this.json.client_version)
+      // Used to check if the rotonde version matches when mod version is present.
+      var version_regex = /^[0-9.]+[a-z]?/;
+      var version_self = this.json.client_version.match(version_regex);
+      var version_portal = r.home.portal.json.client_version.match(version_regex);
+      var version_match =
+        // Don't compare if either string doesn't contain a match.
+        version_self &&
+        version_portal &&
+        version_self[0] == version_portal[0];
+      // The version to display.
+      var version = r.escape_html(this.json.client_version)
         .split(/\r\n|\n/).slice(0, 2).join("<br>"); // Allow 2 lines for mod versions
-      html += "<span class='version "+(client_version_main == r.home.portal.json.client_version ? 'same' : '')+"'>"+this.json.client_version+"</span>"
+      html += "<span class='version "+(version_match ? 'same' : '')+"'>"+version+"</span>"
     }
     
     html += "<span>"+this.json.port.length+" Portals</span>"


### PR DESCRIPTION
Applying the changes outlined in the discussion here: https://github.com/Rotonde/rotonde-client/pull/99#discussion_r149183661

This commit stores the escaped badge version in a temporary variable (doesn't accidentally modify your `portal.json` anymore) and replaces the "split on newline" with a more general purpose regex. This gets `0.1.68` from `0.1.68-modded` and `0.1.68:mod`, but gets `0.1.68b` from `0.1.68beta` (in case releases with alphabetic suffixes become a thing).