### PR TITLE
Merge rotonde-mod 0.1.3 with rotonde-client

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -1,4 +1,4 @@
-body { overflow-x:none; font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#eee; padding-bottom: 140px; width: 100vw; display: flex; flex-direction: column; padding: 0px;}
+body { overflow-x:hidden; font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#eee; padding-bottom: 140px; width: 100vw; display: flex; flex-direction: column; padding: 0px;}
 t { display:inline-block; }
 hr { clear:both; }
 

--- a/links/main.css
+++ b/links/main.css
@@ -1,4 +1,4 @@
-body { font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#eee; padding-bottom: 140px; width: 100vw; display: flex; flex-direction: column; padding: 0px;}
+body { overflow-x:none; font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#eee; padding-bottom: 140px; width: 100vw; display: flex; flex-direction: column; padding: 0px;}
 t { display:inline-block; }
 hr { clear:both; }
 
@@ -48,6 +48,7 @@ body #feed .entry .message i { font-style: italic; }
 body #feed .entry .message del { text-decoration: line-through; }
 body #feed .entry .message.quote { padding:0px 40px; color:#777; margin-top:15px; margin-bottom:10px; font-size:11pt; font-style: italic}
 body #feed .entry .message .highlight { font-weight: bold; color:#555; line-height: 25px; }
+body #feed .entry .message .inline { display: inline-block; margin: 6px 4px -6px 4px; height: 24px; }
 body #feed .entry .portal { margin-right:15px;  display:inline-block; margin-top:10px; font-weight: bold; margin-bottom:5px;}
 body #feed .entry .known_portal { display:inline-block;background: #f4f4f4;padding: 0px 5px;color: #000; }
 body #feed .entry .known_portal:hover { background:#000; color:white; }
@@ -68,8 +69,14 @@ body #feed .entry.whisper { background:black; color:white; }
 body #feed .entry.whisper .icon { filter: invert(100%) }
 body #feed .entry.mention .portal { color:red; }
 
+body #feed .paginator { font-family: "input_mono_regular"; cursor: pointer; user-select: none; text-align: center; }
+body #feed .entry.paginator { padding: 0; }
+body #feed .entry.paginator .message { margin: 16px 0 0 0; font-size: 32px; line-height: 40px; }
+body #feed .badge.paginator .message { margin: 50px auto; font-size: 64px; text-decoration: none; pointer-events: none; }
+
 #wr_timeline { display: block; padding-bottom: 50px; }
 #wr_portals { display: none; background:white;}
+#wr_discovery { display: none; background: white; }
 
 body #feed.mentions .entry { display: none }
 body #feed.mentions .entry.mention { display: block }
@@ -78,9 +85,8 @@ body #feed.mentions #wr_portals { display: block }
 body #feed.mentions #wr_portals { display: none }
 body #feed.portals #wr_portals { display: block }
 body #feed.portals #wr_timeline { display: none; }
-
-#tab_network { background:transparent !important; color:#aaa !important; }
-#tab_network:hover { cursor: default !important; }
+body #feed.discovery #wr_timeline { display: none; }
+body #feed.discovery #wr_discovery { display: block; }
 
 body #feed #tabs { z-index: 600;position: sticky;background: #eee; padding-top:20px; top: 40px; margin-bottom:30px; border-bottom: 1px solid #ccc;}
 body #feed #tabs t { padding:5px 15px; display: inline-block; font-size: 12px; font-weight: bold; color:#aaa; margin-bottom:-1px;}
@@ -92,6 +98,8 @@ body #feed.mentions #tabs :first-child { background:transparent; color:#aaa; }
 body #feed.mentions #tab_mentions { border-bottom:1px solid #000; color:black; }
 body #feed.portals #tab_portals { border-bottom:1px solid #000; color:black; }
 body #feed.portals #tabs :first-child { border-bottom:1px solid #ccc; color:#aaa; }
+body #feed.discovery #tab_discovery { background: white; color: black; }
+body #feed.discovery #tabs :first-child { background: transparent; color: #aaa; }
 
 body #feed #tabs :first-child:hover { background:white !important; color:black !important; }
 
@@ -123,4 +131,4 @@ body #operator #icon { width:40px; height: 40px; display: block; position: absol
 .badge span b { font-weight: bold }
 .badge:hover { background: #f4f4f4; cursor: pointer; }
 
-.badge.discovery { background:transparent; }
+.badge.discovery { background:white; }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -228,7 +228,7 @@ function Feed(feed_urls)
     r.home.feed.tab_portals_el.innerHTML = r.home.feed.portals.length+" Portal"+(r.home.feed.portals.length == 1 ? '' : 's')+"";
     r.home.feed.tab_discovery_el.innerHTML = r.home.discovered_count+"/"+r.home.network.length+" Network"+(r.home.network.length == 1 ? '' : 's')+"";
 
-    var page_marker = pages < 1 ? '' : (' ['+ (this.page + 1) + '/' + pages + ']');
+    var page_marker = pages <= 1 ? '' : (' ['+ (this.page + 1) + '/' + pages + ']');
     var entry_marker = ca + '/';
     if (r.home.feed.target == 'mentions')
       r.home.feed.tab_mentions_el.innerText = entry_marker + r.home.feed.tab_mentions_el.innerText + page_marker;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -112,25 +112,25 @@ function Feed(feed_urls)
 
   this.page_prev = async function()
   {
-    f.page--;
+    r.home.feed.page--;
     r.home.update();
-    await f.refresh('page prev');
+    await r.home.feed.refresh('page prev');
     window.scrollTo(0, document.body.scrollHeight);
   }
 
   this.page_next = async function()
   {
-    f.page++;
+    r.home.feed.page++;
     r.home.update();
-    await f.refresh('page next');
+    await r.home.feed.refresh('page next');
     window.scrollTo(0, 0);
   }
 
   this.page_jump = async function(page)
   {
-    f.page = page;
+    r.home.feed.page = page;
     r.home.update();
-    await f.refresh('page jump ' + f.page);
+    await r.home.feed.refresh('page jump ' + f.page);
   }
 
   this.refresh = function(why)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -31,7 +31,7 @@ function Operator(el)
     this.input_el.addEventListener('dragleave',r.operator.drag_leave, false);
     this.input_el.addEventListener('drop',r.operator.drop, false);
 
-    this.options_el.innerHTML = "<t data-operation='filter keyword'>filter</t> <t data-operation='whisper:user_name message'>whisper</t> <t data-operation='quote:user_name-id message'>quote</t> <t data-operation='message >> media.jpg'>media</t> <t class='right' data-operation='edit:id message'>edit</t> <t class='right' data-operation='delete:id'>delete</t>";
+    this.options_el.innerHTML = "<t data-operation='page:1'>page</t> <t data-operation='filter keyword'>filter</t> <t data-operation='whisper:user_name message'>whisper</t> <t data-operation='quote:user_name-id message'>quote</t> <t data-operation='message >> media.jpg'>media</t> <t class='right' data-operation='edit:id message'>edit</t> <t class='right' data-operation='delete:id'>delete</t>";
 
     this.update();
   }
@@ -247,6 +247,34 @@ function Operator(el)
     }
 
     r.home.add_entry(new Entry(data));
+  }
+
+  this.commands['++'] = function(p, option) {
+    o.commands.page('++');
+  }
+  this.commands['--'] = function(p, option) {
+    o.commands.page('--');
+  }
+  this.commands.page = function(p, option) {
+    if (p === '' || p == null)
+      p = option;
+    if (p === '' || p == null)
+      throw new Error('No parameter given for page command!');
+
+    var page = parseInt(p);
+    if (p.length >= 1 && (p[0] == '+' || p[0] == '-')) {
+      if (isNaN(page))
+          page = p[0] == '+' ? 1 : -1;
+      page += r.home.feed.page;
+    } else {
+      page -= 1;
+    }
+
+    if (isNaN(page))
+      throw new Error('No valid parameter given for page command!');
+    if (page < 0)
+      page = 0;
+    r.home.feed.page_jump(page);
   }
 
   this.autocomplete_words = function()

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -10,6 +10,12 @@ function Portal(url)
 
   this.last_entry = null;
 
+  this.badge_element = null;
+  this.badge_element_html = null;
+
+    // Cache entries when possible.
+    this.cache_entries = {};
+
   this.start = async function()
   {
     var file = await this.archive.readFile('/portal.json',{timeout: 2000}).then(console.log("done!"));
@@ -32,33 +38,47 @@ function Portal(url)
 
   this.connect = async function()
   {
-    console.log("connecting to: ",p.url);
+    console.log('connecting to: ', p.url);
 
     try {
-      p.file = await p.archive.readFile('/portal.json',{timeout: 2000});
+      p.file = await p.archive.readFile('/portal.json', {timeout: 2000});
     } catch (err) {
-      console.log("connection failed: ",p.url)
+      console.log('connection failed: ', p.url);
       r.home.feed.next();
       return;
     } // Bypass slow loading feeds
 
-    p.json = JSON.parse(p.file)
-    r.home.feed.register(p)
+    try {
+      p.json = JSON.parse(p.file);
+      p.url = p.json.dat || p.url;
+      r.home.feed.register(p);
+    } catch (err) {
+      console.log('parsing failed: ', p.url);
+    }
+
     setTimeout(r.home.feed.next, 250);
   }
 
   this.discover = async function()
   {
-    console.log("connecting to: ",p.url);
+    console.log('connecting to: ', p.url);
 
     try {
-      p.file = await p.archive.readFile('/portal.json',{timeout: 2000});
+      p.file = await p.archive.readFile('/portal.json', {timeout: 2000});
     } catch (err) {
-      console.log("connection failed: ",p.url)
+      console.log('connection failed: ', p.url);
+      r.home.discover_next();
       return;
     } // Bypass slow loading feeds
-
-    p.json = JSON.parse(p.file)
+    
+    try {
+      p.json = JSON.parse(p.file);
+    } catch (err) {
+      console.log('parsing failed: ', p.url);
+      r.home.discover_next();
+      return;
+    }
+    
     r.home.discover_next(p);
   }
 
@@ -84,13 +104,16 @@ function Portal(url)
   this.entries = function()
   {
     var e = [];
-    for(id in this.json.feed){
-      var entry = new Entry(this.json.feed[id],p);
+    for (var id in this.json.feed) {
+      var raw = this.json.feed[id];
+      var entry = this.cache_entries[raw.timestamp];
+      if (entry == null)
+        this.cache_entries[raw.timestamp] = entry = new Entry(this.json.feed[id], p);
       entry.id = id;
       entry.is_mention = entry.detect_mention();
       e.push(entry);
     }
-    this.last_entry = e[p.json.feed.length-1];
+    this.last_entry = e[p.json.feed.length - 1];
     return e;
   }
 
@@ -109,6 +132,7 @@ function Portal(url)
 
   this.updated = function()
   {
+    if(this.json == null || this.json.feed == null){ return 0; }
     if(this.json.feed.length < 1){ return 0; }
 
     return p.json.feed[p.json.feed.length-1].timestamp;
@@ -119,8 +143,41 @@ function Portal(url)
     return parseInt((Date.now() - this.updated())/1000);
   }
 
+  this.badge_add = function(special_class, container, c, cmin, cmax)
+  {
+    if (c !== undefined && (c < cmin || cmax <= c)) {
+      // Out of bounds - remove if existing, don't add.
+      if (this.badge_element != null)
+          container.removeChild(this.badge_element);
+      this.badge_element = null;
+      this.badge_element_html = null;
+      return null;
+    }
+
+    var html = this.badge(special_class);
+    if (this.badge_element_html != html) {
+      if (this.badge_element == null) {
+        // Thin wrapper required.
+        this.badge_element = document.createElement('div');
+        this.badge_element.className = 'thin-wrapper';
+      }
+      this.badge_element.innerHTML = html;
+      this.badge_element_html = html;
+      container.appendChild(this.badge_element);
+    }
+    // If c !== undefined, the badge is being added to an ordered collection.
+    if (c !== undefined) {
+      // Always append as last.
+      container.appendChild(this.badge_element);
+    }
+    return this.badge_element;
+  }
+
   this.badge = function(special_class)
   {
+    // Avoid 'null' class.
+    special_class = special_class || '';
+
     var html = "";
 
     html += "<img src='"+this.archive.url+"/media/content/icon.svg'/>";
@@ -152,24 +209,38 @@ function Portal(url)
     
     html += "<span>"+this.json.port.length+" Portals</span>"
 
-    return "<yu class='badge "+special_class+"' data-operation='un"+this.url+"'>"+html+"</yu>";
+    return "<yu class='badge "+special_class+"' data-operation='"+(special_class === "discovery"?"":"un")+this.url+"'>"+html+"</yu>";
   }
 
-  this.is_known = function()
+  this.is_known = function(discovered)
   {
     var archive_hash = this.archive.url.replace("dat://","").replace("/","").trim();
     var portal_hash = this.url.replace("dat://","").replace("/","").trim();
+    var dat_hash = this.json.dat && this.json.dat.replace("dat://","").replace("/","").trim();
 
-    for(id in r.home.feed.portals){
-      var lookup = r.home.feed.portals[id];
+    var portals = [].concat(r.home.feed.portals);
+    if (discovered)
+      portals = portals.concat(r.home.discovered);
+
+    for (id in portals) {
+      var lookup = portals[id];
       var lookup_archive_hash = lookup.archive.url.replace("dat://","").replace("/","").trim();
       var lookup_portal_hash = lookup.url.replace("dat://","").replace("/","").trim();
+      var lookup_dat_hash = lookup.json.dat && lookup.json.dat.replace("dat://","").replace("/","").trim();
 
-      if(lookup_archive_hash === portal_hash){ return true; }
-      if(lookup_portal_hash === portal_hash){ return true; }
-      if(lookup_archive_hash === archive_hash){ return true; }
-      if(lookup_portal_hash === archive_hash){ return true; }
+      if (lookup_archive_hash === archive_hash) return true;
+      if (lookup_archive_hash === portal_hash) return true;
+      if (lookup_archive_hash === dat_hash && dat_hash) return true;
+      if (lookup_portal_hash === archive_hash) return true;
+      if (lookup_portal_hash === portal_hash) return true;
+      if (lookup_portal_hash === dat_hash && dat_hash) return true;
+      if (lookup_dat_hash) {
+        if (lookup_dat_hash === archive_hash) return true;
+        if (lookup_dat_hash === portal_hash) return true;
+        if (lookup_dat_hash === dat_hash && dat_hash) return true;
+      }
     }
+
     return false;
   }
 }


### PR DESCRIPTION
I honestly don't expect this PR to be merged as-is, but hope that at least parts of it will find their way into rotonde-client.

This will hurt a little because
* I format my code in rotonde-mod differently than the code in rotonde-client
* `Feed.refresh` now counts more than it should (sorry, @eelfroth )
* `r.home.feed.page` is being used in discovery
* The discovery "renderer" is currently part of `Home.update`

The good news, though, is that the pagination and the related element reuse changes reduced the crash rate. We're not manipulating the DOM via `innerHTML` as aggressively anymore. I assume Beaker 0.8 will just deal with DOM updates better?

This adds the following features:

![image](https://user-images.githubusercontent.com/1200380/32575840-66fdad92-c4d5-11e7-8bb5-fcdf441c1678.png)
* `Visible/All` in tab title

![image](https://user-images.githubusercontent.com/1200380/32575983-db7c570e-c4d5-11e7-9880-8cbb42fa04b9.png)
* Pagination
  * Current / last page displayed in tab title
  * New commands: `page:#` (alt: `page #`), `++`, `--`
  * Functional in main feed, mentions, discovery

![image](https://user-images.githubusercontent.com/1200380/32576296-dee42c9a-c4d6-11e7-95aa-b5732738239e.png)
* Inline image support
  * `{%image.svg%}` => `<img>`, src = ``/media/content/inline/image.svg` (currently default file format if none given: `.png`)
  * Displays name on mouse over
  * Currently styled as following: `body #feed .entry .message .inline { display: inline-block; margin: 6px 4px -6px 4px; height: 24px; }`
  * Same origin rules as media, making everyone host their own inline images in `/media/content/inline/`

![image](https://user-images.githubusercontent.com/1200380/32576501-6f044b7a-c4d7-11e7-97e0-3107b8a34882.png)
* Functional discovery tab (currently hiding behind "Networks")
  * Allows discovering new portals based on the portals you're already following
  * Sorted by activity
  * Paginated

I didn't include `.ext#URL/.` media support because it requires `/media/content/.ext/index.html` redirecting to `window.location.hash` for backwards-compatibility and because it allows non-self-hosted media.