### PR TITLE
Fix mentions, fix #102

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -50,13 +50,6 @@ function Entry(data,host)
 
   this.to_html = function()
   {
-    this.is_mention = false;
-    for(i in this.target){
-      if(to_hash(this.target[i]) == to_hash(r.home.portal.url)){
-        this.is_mention = true;
-        break;
-      }
-    }
     var html = "";
 
     html += this.icon();
@@ -277,10 +270,7 @@ function Entry(data,host)
   this.is_visible = function(filter = null,feed_target = null)
   {
     if(feed_target == "mentions"){
-      feed_target = null;
-      if(! this.is_mention){
-        return false;
-      }
+      return this.is_mention;
     }
     if(this.whisper && this.host.json.name != r.home.portal.json.name){
       for(url in this.target){
@@ -310,7 +300,11 @@ function Entry(data,host)
           }
       }
 
-      if(this.message.toLowerCase().indexOf(r.home.portal.json.name) > -1){
+      // Mention tag, eg '@dc'
+      const mentionTag = '@' + r.home.portal.json.name
+      const msg = this.message.toLowerCase()
+      // We want to match messages containing @dc, but NOT ones containing eg. @dcorbin
+      if(msg.endsWith(mentionTag) || msg.indexOf(mentionTag + ' ') > -1) {
         im = true;
       }
       for(var i in this.target){
@@ -321,11 +315,10 @@ function Entry(data,host)
       }
     }
 
-    if(im){
-      r.home.feed.mentions += 1;
-    }
     return im;
   }
+
+  this.is_mention = this.detect_mention()
 }
 
 function timeSince(date)

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -41,7 +41,7 @@ function Feed(feed_urls)
 
   this.urls = {};
   this.filter = "";
-  this.target = window.location.hash ? window.location.hash.replace("#","") : "entries";
+  this.target = window.location.hash ? window.location.hash.replace("#","") : "";
   this.timer = null;
   this.mentions = 0;
 
@@ -154,6 +154,9 @@ function Feed(feed_urls)
       entries = entries.concat(portal.entries())
     }
 
+    this.mentions = entries.filter(function (e) { return e.is_mention }).length
+    if(this.mentions > 0) { console.log("we got mentioned!","×"+this.mentions); }
+
     var sorted_entries = entries.sort(function (a, b) {
       return a.timestamp < b.timestamp ? 1 : -1;
     });
@@ -221,7 +224,6 @@ function Feed(feed_urls)
       }
     }
 
-    if(this.mentions > 0) { console.log("we got mentioned!","×"+this.mentions); }
 
     r.home.feed.tab_timeline_el.innerHTML = entries.length+" Entries";
     r.home.feed.tab_mentions_el.innerHTML = this.mentions+" Mention"+(this.mentions == 1 ? '' : 's')+"";


### PR DESCRIPTION
### single code path for detecting mentions

before, mentions were computed two different ways--one way for the count, another way for filtering, resulting in #102

### fixes the default page

loads the Entries tab automatically. i broke this a few commits ago, sorry