### PR TITLE
Fix ++, --, page_jump and clear_filter

### DIFF
--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -130,7 +130,7 @@ function Feed(feed_urls)
   {
     r.home.feed.page = page;
     r.home.update();
-    await r.home.feed.refresh('page jump ' + f.page);
+    await r.home.feed.refresh('page jump ' + r.home.feed.page);
   }
 
   this.refresh = function(why)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -187,18 +187,16 @@ function Operator(el)
 
   this.commands.filter = function(p,option)
   {
-    var target = option ? option : "";
+    var target = option || "";
     window.location.hash = target;
     r.home.feed.target = target;
     r.home.feed.el.className = target;
-    r.home.feed.filter = p;
+    r.home.feed.filter = p || "";
   }
 
   this.commands.clear_filter = function()
   {
-    window.location.hash = "";
-    r.home.feed.filter = "";
-    r.home.feed.target = "";
+    r.operator.commands.filter();
   }
 
   this.commands.quote = function(p,option)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -250,10 +250,10 @@ function Operator(el)
   }
 
   this.commands['++'] = function(p, option) {
-    o.commands.page('++');
+    r.operator.commands.page('++');
   }
   this.commands['--'] = function(p, option) {
-    o.commands.page('--');
+    r.operator.commands.page('--');
   }
   this.commands.page = function(p, option) {
     if (p === '' || p == null)


### PR DESCRIPTION
This fixes:

* The feed not resetting the filters properly (fixes broken feed)
* The `++`, `--` commands and `Feed.page_jump` still referring to rotonde-mod helper variables (those should be the last, I hope...)