### PR TITLE
Make to_hash trim /* and add Portal.hashes(), has_hash(hashes_a, hashes_b)

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -274,7 +274,7 @@ function Entry(data,host)
     }
     if(this.whisper && this.host.json.name != r.home.portal.json.name){
       for(url in this.target){
-        if(to_hash(url) != to_hash(r.home.portal.url)){
+        if(has_hash(r.home.portal.hashes(), url)){
           return false;
         }
       }
@@ -307,8 +307,9 @@ function Entry(data,host)
       if(msg.endsWith(mentionTag) || msg.indexOf(mentionTag + ' ') > -1) {
         im = true;
       }
+      var hashes = r.home.portal.hashes();
       for(var i in this.target){
-        if(to_hash(this.target[i]) == to_hash(r.home.portal.url)){
+        if(has_hash(hashes, this.target[i])){
           im = true;
           break;
         }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -92,7 +92,7 @@ function Feed(feed_urls)
     for (var id = 0; id < r.home.portal.json.port.length; id++) {
       var port_url = r.home.portal.json.port[id];
       if (port_url != portal.url) continue;
-      r.home.portal.json.port[id] = portal.json.dat || portal.url;
+      r.home.portal.json.port[id] = portal.json.dat || portal.archive.url || portal.url;
       break;
     }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -262,7 +262,7 @@ function has_hash(hashes_a, hashes_b)
 {
   // Passed a single url or hash as hashes_b. Let's support it for convenience.
   if (typeof(hashes_b) == "string")
-    return hashes_a.indexOf(to_hash(hashes_b)) > -1;
+    return hashes_a.findIndex(hash_a => to_hash(hash_a) == to_hash(hashes_b)) > -1;
   
   for (var a in hashes_a) {
     var hash_a = to_hash(hashes_a[a]);

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -246,7 +246,41 @@ function Feed(feed_urls)
 
 function to_hash(url)
 {
-  return url.replace("dat://","").replace("/","").trim();
+  if (!url)
+    return null;
+
+  url = url.replace("dat://", "");
+
+  var index = url.indexOf("/");
+  url = index == -1 ? url : url.substring(0, index);
+
+  url = url.trim();
+  return url;
+}
+
+function has_hash(hashes_a, hashes_b)
+{
+  // Passed a single url or hash as hashes_b. Let's support it for convenience.
+  if (typeof(hashes_b) == "string")
+    return hashes_a.indexOf(to_hash(hashes_b)) > -1;
+  
+  for (var a in hashes_a) {
+    var hash_a = to_hash(hashes_a[a]);
+    if (!hash_a)
+      continue;
+
+    for (var b in hashes_b) {
+      var hash_b = to_hash(hashes_b[b]);
+      if (!hash_b)
+        continue;
+
+      if (hash_a == hash_b)
+        return true;
+    }
+
+  }
+
+  return false;
 }
 
 function portal_from_hash(url)
@@ -254,9 +288,9 @@ function portal_from_hash(url)
   var hash = to_hash(url);
 
   for(id in r.home.feed.portals){
-    if(hash == to_hash(r.home.feed.portals[id].url)){ return "@"+r.home.feed.portals[id].json.name; }
+    if(has_hash(r.home.feed.portals[id].hashes(), hash)){ return "@"+r.home.feed.portals[id].json.name; }
   }
-  if(hash == to_hash(r.home.portal.hash)){
+  if(has_hash(r.home.portal.hashes(), hash)){
     return "@"+r.home.portal.json.name;
   }
   return hash.substr(0,12)+".."+hash.substr(hash.length-3,2);

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -89,6 +89,13 @@ function Feed(feed_urls)
   {
     console.info("connected to ",portal.json.name,this.portals.length+"|"+this.queue.length);
 
+    for (var id = 0; id < r.home.portal.json.port.length; id++) {
+      var port_url = r.home.portal.json.port[id];
+      if (port_url != portal.url) continue;
+      r.home.portal.json.port[id] = portal.json.dat || portal.url;
+      break;
+    }
+
     this.portals.push(portal);
     var activity = portal.archive.createFileActivityStream("portal.json");
     activity.addEventListener('changed', e => {

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -214,10 +214,7 @@ function Home()
       return;
     }
 
-    r.home.discovered_hashes.push(portal.url.replace("dat://","").replace("/","").trim());
-    r.home.discovered_hashes.push(portal.archive.url.replace("dat://","").replace("/","").trim());
-    if (portal.json.dat)
-      r.home.discovered_hashes.push(portal.json.dat.replace("dat://","").replace("/","").trim());
+    r.home.discovered_hashes = r.home.discovered_hashes.concat(portal.hashes());
     
     if (portal.is_known(true)) {
       return;
@@ -232,10 +229,10 @@ function Home()
   {
     var url;
     while (r.home.discovering < r.home.network.length - 1 &&
-           r.home.discovered_hashes.indexOf(
+           has_hash(r.home.discovered_hashes,
              (url = r.home.network[++r.home.discovering])
              .replace("dat://","").replace("/","").trim()
-           ) > -1) { }
+           )) { }
 
     if (r.home.discovering >= r.home.network.length) {
       r.home.discovering = -1;

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -165,8 +165,7 @@ function Operator(el)
 
   this.commands.dat = function(p,option)
   {
-    option = option.replace("dat://","").replace(/\//g,"").trim();
-    if(option.length != 64){ console.log("Invalid url: ",option); return; }
+    option = to_hash(option);
 
     for(id in r.home.portal.json.port){
       var port_url = r.home.portal.json.port[id];

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -27,12 +27,13 @@ function Portal(url)
   {
     // Remove portals duplicate
     var portals = [];
+    this.json.port = [];
     for(id in this.json.port){
-      var url = this.json.port[id].replace("dat://","").replace("/","").trim();
-      if(url.length != 64 || portals.indexOf(url) > -1){ continue; }
-      portals.push("dat://"+url+"/")
+      var hash = to_hash(this.json.port[id]);
+      if(has_hash(portals, hash)){ continue; }
+      portals.push(hash);
+      this.json.port.push("dat://"+hash+"/");
     }
-    this.json.port = portals;
   }
 
   this.connect = async function()
@@ -117,14 +118,10 @@ function Portal(url)
 
   this.relationship = function(target = r.home.url)
   {
-    target = target.replace("dat://","").replace("/","").trim();
+    target = to_hash(target);
 
-    for(id in this.json.port){
-      var hash = this.json.port[id];
-      if(hash.indexOf(target) > -1){
-        return "@";
-      }
-    }
+    if (has_hash(this.json.port, target)) return "@";
+
     return "~";
   }
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -26,12 +26,13 @@ function Portal(url)
   this.maintenance = function()
   {
     // Remove portals duplicate
-    var portals = [];
+    var checked = [];
+    var portals = this.json.port;
     this.json.port = [];
-    for(id in this.json.port){
-      var hash = to_hash(this.json.port[id]);
-      if(has_hash(portals, hash)){ continue; }
-      portals.push(hash);
+    for(id in portals){
+      var hash = to_hash(portals[id]);
+      if(has_hash(checked, hash)){ continue; }
+      checked.push(hash);
       this.json.port.push("dat://"+hash+"/");
     }
   }


### PR DESCRIPTION
* Some people shared dat URLs with `/index.html` (or similar) appended. `to_hash` now removes anything past the first `/` in the URL.
* `Portal.hashes()` gets all possible hashes from (currently) `portal.url`, `portal.archive.url`, `portal.json.dat`
* `has_hash(hashes_a, hashes_b)` allows us to check the results of `Portal.hashes()` against each other. Optionally, hashes_b can be a single hash. Also optionally, `has_hash` supports urls (it calls `to_hash` internally) just in case we accidentally pass on the URLs un-`to_hash`-ed.

This should fix various mention, whisper, and portal relationship issues when the URLs were malformed, or when the `dat` in `portal.json` wasn't taken into account.