### PR TITLE
Add "/" to URLs in port list if missing; Fix whisper visibility

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -272,12 +272,13 @@ function Entry(data,host)
     if(feed_target == "mentions"){
       return this.is_mention;
     }
-    if(this.whisper && this.host.json.name != r.home.portal.json.name){
+    if(this.whisper){
       for(url in this.target){
         if(has_hash(r.home.portal.hashes(), url)){
-          return false;
+          return true;
         }
       }
+      return false;
     }
     if(filter && this.message.indexOf(filter) < 0){
       return false;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -93,6 +93,8 @@ function Feed(feed_urls)
       var port_url = r.home.portal.json.port[id];
       if (port_url != portal.url) continue;
       r.home.portal.json.port[id] = portal.json.dat || portal.archive.url || portal.url;
+      if (!r.home.portal.json.port[id].replace("dat://", "").indexOf("/") > -1)
+        r.home.portal.json.port[id] = r.home.portal.json.port[id] + "/";
       break;
     }
 


### PR DESCRIPTION
* I noticed other whispers being visible on my timeline. I accidentally broke it with #113, sorry about that. Fixed it.
* Very minor thing: The port URL fixer uses the archive URLs, but they don't end with `/`. The port URL fixer now adds the "missing" `/`.