### PR TITLE
Add portal.dat ~ DatArchive.resolveName(url), use it over dat in portal.json

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -121,7 +121,15 @@ function Rotonde(client_url)
 
   this.reset_with_name = async function()
   {
-    this.home.portal.json = {name: name,desc: "new_desc",port:[],feed:[],site:"",dat:""}
+    this.home.portal.json = {
+      name: name,
+      desc: "new_desc",
+      port: [],
+      feed: [],
+      site: "",
+      // Deprecated but required to keep old versions working as long as possible.
+      dat: ""
+    };
     this.home.save();
     r.home.feed.refresh("reset_with_name");
   }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -89,12 +89,14 @@ function Feed(feed_urls)
   {
     console.info("connected to ",portal.json.name,this.portals.length+"|"+this.queue.length);
 
+    // Fix the URL of the registered portal.
     for (var id = 0; id < r.home.portal.json.port.length; id++) {
       var port_url = r.home.portal.json.port[id];
       if (port_url != portal.url) continue;
-      r.home.portal.json.port[id] = portal.json.dat || portal.archive.url || portal.url;
-      if (!r.home.portal.json.port[id].replace("dat://", "").indexOf("/") > -1)
-        r.home.portal.json.port[id] = r.home.portal.json.port[id] + "/";
+      port_url = portal.archive.url || portal.url;
+      if (!port_url.replace("dat://", "").indexOf("/") > -1)
+        port_url = port_url + "/";
+      r.home.portal.json.port[id] = port_url;
       break;
     }
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -6,6 +6,11 @@ function Portal(url)
   this.file = null;
   this.json = null;
   this.archive = new DatArchive(this.url);
+  // Resolve "masked" (f.e. hashbase) dat URLs to "hashed" (dat://0123456789abcdef/) one.
+  DatArchive.resolveName(this.url).then(hash => {
+    if (!hash) return;
+    this.dat = "dat://"+hash+"/";
+  });
 
   this.last_entry = null;
 
@@ -213,7 +218,7 @@ function Portal(url)
     var hashes = [];
     hashes.push(to_hash(this.url));
     hashes.push(to_hash(this.archive.url));
-    hashes.push(to_hash(this.json.dat));
+    hashes.push(to_hash(this.dat));
     // Remove falsy entries.
     for (var i = 0; i < hashes.length; i++) {
       if (!hashes[i]) {


### PR DESCRIPTION
Related discussion on Twitter, linking to thread tail: https://twitter.com/lechd/status/929056891409453056

The `dat` field in `portal.json` is just causing issues and @neauoire told me about `DatArchive.resolveName`, which is preferable for every use case in rotonde right now (except for when someone wants to "update" their portal to a new dat).

This makes `portal.hashes()` (used in f.e. `is_known`, mention / whisper checking) effectively return the result of `resolveName`.

`dat` in `portal.json` is now useless (can't find anything using it anymore), but it's still being kept as old client versions use it.