### PR TITLE
Make has_hash handle portals as args; Fix refresh on save

### DIFF
--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -146,9 +146,8 @@ function Feed(feed_urls)
 
   this.refresh = function(why)
   {
-    if (why && !why.startsWith('delayed: ') && (
-        why == 'saved'
-    )) {
+    if (why && why.startsWith("delay: ")) {
+      why = why.replace("delay: ", "");
       // Delay the refresh to occur again after all portals refreshed.
       setTimeout(async function() {
         for (var id in r.home.feed.portals) {
@@ -271,6 +270,12 @@ function to_hash(url)
 
 function has_hash(hashes_a, hashes_b)
 {
+  // Passed a portal (or something giving hashes) as hashes_a or hashes_b.
+  if (typeof(hashes_a.hashes) == "function")
+    hashes_a = hashes_a.hashes();
+  if (typeof(hashes_b.hashes) == "function")
+    hashes_b = hashes_b.hashes();
+
   // Passed a single url or hash as hashes_b. Let's support it for convenience.
   if (typeof(hashes_b) == "string")
     return hashes_a.findIndex(hash_a => to_hash(hash_a) == to_hash(hashes_b)) > -1;
@@ -299,9 +304,9 @@ function portal_from_hash(url)
   var hash = to_hash(url);
 
   for(id in r.home.feed.portals){
-    if(has_hash(r.home.feed.portals[id].hashes(), hash)){ return "@"+r.home.feed.portals[id].json.name; }
+    if(has_hash(r.home.feed.portals[id], hash)){ return "@"+r.home.feed.portals[id].json.name; }
   }
-  if(has_hash(r.home.portal.hashes(), hash)){
+  if(has_hash(r.home.portal, hash)){
     return "@"+r.home.portal.json.name;
   }
   return hash.substr(0,12)+".."+hash.substr(hash.length-3,2);

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -159,9 +159,9 @@ function Home()
     await archive.writeFile('/portal.json', JSON.stringify(this.portal.json, null, 2));
     await archive.commit();
 
-    this.portal.refresh("saved");
+    // this.portal.refresh("saved");
     this.update();
-    r.home.feed.refresh("saved");
+    r.home.feed.refresh("delay: saved");
   }
 
   this.discover = async function()

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -238,7 +238,7 @@ function Portal(url)
 
     for (id in portals) {
       var lookup = portals[id];
-      if (has_hash(hashes, lookup.hashes()))
+      if (has_hash(hashes, lookup))
         return true;
     }
 


### PR DESCRIPTION
* Code "quality of life": `has_hash` now checks if the left or right side has got a `hashes` function. If so, it calls it and uses its result. This allows us to simply pass the portals to `has_hash`.
* @neauoire I've identified the bug you were experiencing earlier. When posting something (and thus saving), our own portal got refreshed twice, as it exists in both `r.home.portal` and `r.home.feed.portals`. This fixes the "my own posts get glitched to the top when posting" issue :)