### PR TITLE
media formats, no scroll on input, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ That goal of this tutorial is to have both a local client and portal.
 
 - `dat://000` will follow a portal.
 - `undat://000` will unfollow a portal.
-- `filter @neauoire` will show your mentions.
+- `filter word` will show entries containing `word`.
+- `filter:neauoire` will show entries by `~neauoire`.
 - `clear_filter` will clear the filtered feed.
 - `edit:name alice` will change your display name to `~alice`.
 - `edit:desc This is a brand new description` will change your display description.
@@ -43,6 +44,9 @@ That goal of this tutorial is to have both a local client and portal.
 - `quote:user_name-3` will quote another user's entry, where *3* is the entry ID 3. 
 - `quote:user_name-3 Have a look at this!` will quote another user's entry, and add the entry `Have a look at this!`. 
 - `whisper:username Psst!`
+- `++` will show the next page of entries
+- `--` will show the previous page
+- `page:5` will jump to page 5
 
 ## Runes
 
@@ -51,10 +55,23 @@ That goal of this tutorial is to have both a local client and portal.
 - `&` means that the message is a whisper.
 - `$` means that they are a service or a bot.
 
+## Tabs
+
+- `Entries` shows the combined feeds of all followed portals.
+- `Mentions` shows entries that mention or quote you.
+- `Whispers` shows your whispers.
+- `Portals` shows a list of portals you follow.
+- `Networks` shows portals that are followed by the portals you follow.
+
 ## Icon
 
 To change your display icon, update the SVG file located at `media/content/icon.svg`. The icon should be a square file for it to display properly. Keep it small. If you update your SVG manually, don't forget to go to *Library -> (Your Rotonde Site)* and press *Review Changes -> Publish*, otherwise your changes wont be seen by anyone!
 
 ## Rich content
 
-- `TEXT >> MEDIA_NAME.jpg`, will connect a media filename from `media/content/MEDIA_NAME.jpg`.
+- `TEXT >> MEDIA_NAME.jpg` will connect a media filename from `media/content/MEDIA_NAME.jpg`.
+- `TEXT {%CUSTOM_EMOJI%} TEXT` will inline an image file from `media/content/inline/CUSTOM_EMOJI.png`.
+- suppoted media types are:  
+image: gif, jpg, png, svg, webp  
+video: ogv, webm, mp4  
+audio: ogg, opus, mp3, m4a

--- a/rotonde.js
+++ b/rotonde.js
@@ -109,7 +109,6 @@ function Rotonde(client_url)
     e.preventDefault();
 
     r.operator.inject(e.target.getAttribute("data-operation"));
-    window.scrollTo(0, 0);
     if(!e.target.getAttribute("data-validate")){ return; }
     r.operator.validate();
   }

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -123,9 +123,9 @@ function Entry(data,host)
         this.media += ".jpg";
         extension = "jpg";
       } // support og media uploads
-      audiotypes = ["mp3", "ogg", "wav"];
-      videotypes = ["mp4", "webm"]; // "ogg",
-      imagetypes = ["apng", "bmp", "dib", "gif", "jpg", "jpeg", "jpe", "png", "svg", "svgz", "tiff", "tif", "webp"];
+      audiotypes = ["m4a", "mp3", "oga", "ogg", "opus"];
+      videotypes = ["mp4", "ogv", "webm"];
+      imagetypes = ["apng", "gif", "jpg", "jpeg", "jpe", "png", "svg", "svgz", "tiff", "tif", "webp"];
 
       var origin = this.quote && this.target ? this.target : this.host.url;
 

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -68,16 +68,17 @@ function Operator(el)
     var option = command.indexOf(":") > -1 ? command.split(":")[1] : null;
     command = command.indexOf(":") > -1 ? command.split(":")[0] : command;
 
+    if(!this.commands[command]){
+      command = "say";
+      params = this.input_el.value.trim();
+    }
+
     this.cmd_history.push(this.input_el.value);
     this.cmd_index = -1;
     this.cmd_buffer = "";
 
-    if(this.commands[command]){
-      this.commands[command](params,option);
-    }
-    else{
-      this.commands.say(this.input_el.value.trim());
-    }
+    this.commands[command](params,option);
+
     this.input_el.value = "";
     r.home.feed.refresh(command+" validated");
   }
@@ -294,6 +295,8 @@ function Operator(el)
 
   this.key_down = function(e)
   {
+    var scroll = document.body.scrollTop;
+
     if(e.key == "Enter" && !e.shiftKey){
       e.preventDefault();
       r.operator.validate();
@@ -358,6 +361,7 @@ function Operator(el)
     }
 
     r.operator.update();
+    setTimeout(window.scrollTo, 1, 0, scroll);
   }
 
   this.input_changed = function(e)


### PR DESCRIPTION
was missing some media formats that also work in beaker, so I added them. uncompressed formats seem stupid on the dat web, so I removed support for them.

it was very disorienting that the page scrolled to `(0, 0)` every time you clicked something or started typing, so I fixed that.
\+ I fixed the reason parameter for refresh on validating `say` commads

and I updated the documentation to better reflect the current feature set