### PR TITLE
Added help command

### DIFF
--- a/scripts/home.js
+++ b/scripts/home.js
@@ -27,6 +27,8 @@ function Home()
   this.discovery_page_size = 16;
   this.discovering = -1;
 
+  this.display_log = true;
+
   this.install = function()
   {
     r.el.appendChild(r.home.el);
@@ -121,9 +123,19 @@ function Home()
 
   }
 
-  this.log = function(text)
+  this.log = function(text, life)
   {
-    r.operator.input_el.setAttribute("placeholder",text);
+    if (this.display_log) {
+      if (life && life !== 0) {
+        this.display_log = false;
+        var t = this;
+        setTimeout(function() {
+            t.display_log = true;
+        }, life);
+      }
+
+      r.operator.input_el.setAttribute("placeholder",text);
+    }
   }
 
   this.collect_network = function()
@@ -184,22 +196,22 @@ function Home()
   this.discover_next = function(portal)
   {
     setTimeout(r.home.discover_next_step, 250);
-    
+
     if (!portal) {
       return;
     }
 
     r.home.discovered_hashes = r.home.discovered_hashes.concat(portal.hashes());
-    
+
     if (portal.is_known(true)) {
       return;
     }
-    
+
     r.home.discovered.push(portal);
     r.home.update();
     r.home.feed.refresh("discovery");
   }
-  
+
   this.discover_next_step = function()
   {
     var url;
@@ -213,7 +225,7 @@ function Home()
       r.home.discovering = -1;
       return;
     }
-        
+
     try {
       var portal = new Portal(url);
       portal.discover();

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -16,6 +16,7 @@ function Operator(el)
   this.el.appendChild(this.options_el)
 
   this.name_pattern = new RegExp(/^@(\w+)/, "i");
+  this.keywords = ["filter","whisper","quote","edit","delete","page","++","--","help"];
 
   this.cmd_history = [];
   this.cmd_index = -1;
@@ -50,9 +51,7 @@ function Operator(el)
     this.rune_el.innerHTML = ">";
     this.rune_el.className = input.length > 0 ? "input" : "";
 
-    var keywords = ["filter","whisper","quote","edit","delete","help"]
-
-    if(keywords.indexOf(input.split(" ")[0]) > -1 || input.indexOf(":") > -1){
+    if(this.keywords.indexOf(input.split(" ")[0]) > -1 || input.indexOf(":") > -1){
       this.rune_el.innerHTML = "$";
     }
     if(input.indexOf(">>") > -1){
@@ -279,13 +278,12 @@ function Operator(el)
         p = option;
 
       var life = 1500;
-      var keywords = "filter whisper quote media edit delete help";
       if (p === '' || p === null) {
-          r.home.log(keywords, life);
+          r.home.log(r.operator.keywords.join(' '), life);
       } else {
           var command = p.split(' ')[0];
           if (command == "filter") {
-              r.home.log('filter keyword', life);
+              r.home.log('filter:keyword', life);
           }
           else if (command == "whisper") {
               r.home.log('whisper:user_name message', life);
@@ -301,6 +299,9 @@ function Operator(el)
           }
           else if (command == "delete") {
               r.home.log('delete:id', life);
+          }
+          else if (command == "page") {
+              r.home.log('page:page_number', life);
           }
           else if (command == "help") {
               r.home.log('help:command', life);

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -50,7 +50,7 @@ function Operator(el)
     this.rune_el.innerHTML = ">";
     this.rune_el.className = input.length > 0 ? "input" : "";
 
-    var keywords = ["filter","whisper","quote","edit","delete"]
+    var keywords = ["filter","whisper","quote","edit","delete","help"]
 
     if(keywords.indexOf(input.split(" ")[0]) > -1 || input.indexOf(":") > -1){
       this.rune_el.innerHTML = "$";
@@ -274,7 +274,41 @@ function Operator(el)
       page = 0;
     r.home.feed.page_jump(page);
   }
+  this.commands.help = function(p, option) {
+      if (p === '' || p == null)
+        p = option;
 
+      var life = 1500;
+      var keywords = "filter whisper quote media edit delete help";
+      if (p === '' || p === null) {
+          r.home.log(keywords, life);
+      } else {
+          var command = p.split(' ')[0];
+          if (command == "filter") {
+              r.home.log('filter keyword', life);
+          }
+          else if (command == "whisper") {
+              r.home.log('whisper:user_name message', life);
+          }
+          else if (command == "quote") {
+              r.home.log('quote:user_name-id message', life);
+          }
+          else if (command == "media") {
+              r.home.log('message >> media.jpg', life);
+          }
+          else if (command == "edit") {
+              r.home.log('edit:id message', life);
+          }
+          else if (command == "delete") {
+              r.home.log('delete:id', life);
+          }
+          else if (command == "help") {
+              r.home.log('help:command', life);
+          } else {
+              throw new Error('Invalid parameter given for help command!');
+          }
+      }
+  }
   this.autocomplete_words = function()
   {
     var words = r.operator.input_el.value.split(" ");


### PR DESCRIPTION
I really miss the help-on-click from 0.1.6, so I've built one that fits the current version. The `help` command without parameters prints the existing commands. 

I've also needed to change the `home.log` function, because the helps disappeared too fast, but you can use it without the `life` parameters too. 

It's OK if it doesn't gets accepted. :D 