### PR TITLE
Speed up connection process - remove r.home.feed.last_update

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -145,7 +145,9 @@ function Entry(data,host)
     if(this.quote){
       return "+";
     }
-    if(this.target){
+    if(this.target && this.target.length != 0){
+      // Fun fact: this.target.length != 0 works for strings ("".length == 0),
+      // but also for arrays ([].length == 0).
       return ":";
     }
     return "";

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -72,12 +72,9 @@ function Feed(feed_urls)
     this.timer = setInterval(r.home.feed.next, 500);
   }
 
-  this.last_update = Date.now();
-
   this.next = async function()
   {
     if(r.home.feed.queue.length < 1){ console.log("Reached end of queue"); r.home.feed.update_log(); return; }
-    if(Date.now() - r.home.feed.last_update < 250){ return; }
 
     var url = r.home.feed.queue[0];
 
@@ -86,7 +83,6 @@ function Feed(feed_urls)
     var portal = new Portal(url);
     portal.connect()
     r.home.feed.update_log();
-    r.home.feed.last_update = Date.now();
   }
 
   this.register = async function(portal)

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -182,25 +182,26 @@ function Home()
   }
 
   this.discover_next = function(portal)
-  {
-    setTimeout(r.home.discover_next_step, 250);
-    
+  {    
     if (!portal) {
+      r.home.discover_next_step();
       return;
     }
 
     r.home.discovered_hashes = r.home.discovered_hashes.concat(portal.hashes());
     
     if (portal.is_known(true)) {
+      r.home.discover_next_step();
       return;
     }
     
     r.home.discovered.push(portal);
     r.home.update();
     r.home.feed.refresh("discovery");
+    setTimeout(r.home.discover_next_step, 250);
   }
   
-  this.discover_next_step = function()
+  this.discover_next_step = async function()
   {
     var url;
     while (r.home.discovering < r.home.network.length - 1 &&
@@ -214,12 +215,8 @@ function Home()
       return;
     }
         
-    try {
-      var portal = new Portal(url);
-      portal.discover();
-    } catch (err) {
-      // Hopefully we can catch the beaker crash...
-    }
+     var portal = new Portal(url);
+     await portal.discover();
   }
 }
 

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -204,19 +204,19 @@ function Home()
   this.discover_next_step = async function()
   {
     var url;
-    while (r.home.discovering < r.home.network.length - 1 &&
+    while (!url && r.home.discovering < r.home.network.length - 1 &&
            has_hash(r.home.discovered_hashes,
              (url = r.home.network[++r.home.discovering])
              .replace("dat://","").replace("/","").trim()
            )) { }
 
-    if (r.home.discovering >= r.home.network.length) {
+    if (r.home.discovering >= r.home.network.length - 1) {
       r.home.discovering = -1;
       return;
     }
-        
-     var portal = new Portal(url);
-     await portal.discover();
+    
+    var portal = new Portal(url);
+    await portal.discover();
   }
 }
 


### PR DESCRIPTION
This allows the portals to connect way faster. In `Portal.connect`, when a connection succeeds, it still connects to the next portal after 250ms. But when a connection failed, rotonde now immediately tries connecting to the next portal in the queue.

Before this change, it already attempted doing the same, but failed due to the "time of last update" check in `r.home.feed.next`.

The timeouts are unchanged.

This helps greatly when you're following many portals.

Edit: I'm also smuggling a small fix for the `:` rune being used in entry headers even when no targets are given.