### PR TITLE
Add Rotonde Launchapd

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,13 @@
 
 <div class="pane-view">
   <section id="landing-page" class="pane pane--active pane--fade-left">
-    <h1>Rotonde Launchpad</h1>
-    <button id="ignition" class="button" tabindex="0">Start your own portal!</button>
+    <h1>Rotonde</h1>
+    <button id="start-your-portal" class="button" tabindex="0">
+      Start your own portal
+    </button>
   </section>
 
-  <section id="create-portal" class="pane pane--fade-right">
+  <section id="create-portal-form" class="pane pane--fade-right">
     <div class="field avatar" data-help="svg only atm">
       <label for="avatar" tabindex="0">
         <img src="/site/icon.svg" />
@@ -31,7 +33,9 @@
       <input id="website" type="text" placeholder="Website (Optional)" tabindex="0"/>
     </div>
 
-    <button id="liftoff" class="button" tabindex="0">Launch!</button>
+    <button id="create-portal" class="button" tabindex="0">
+      Create Your Portal!
+    </button>
 
     <button id="close" class="icon-button" tabindex="0">
       <img src="/site/close.svg" alt="close"/>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     </button>
   </section>
 
-  <section id="create-portal-form" class="pane pane--fade-right">
+  <section id="create-portal-page" class="pane pane--fade-right">
     <div class="field avatar" data-help="svg only atm">
       <label for="avatar" tabindex="0">
         <img src="/site/icon.svg" />
@@ -37,7 +37,23 @@
       Create Your Portal!
     </button>
 
-    <button id="close" class="icon-button" tabindex="0">
+    <button id="close-create-portal-page" class="icon-button close" tabindex="0">
+      <img src="/site/close.svg" alt="close"/>
+    </button>
+  </section>
+
+  <section id="congrats-page" class="pane pane--fade-left pane--active">
+    <article>
+      <h1>Welcome</h1>
+      <p>
+        You now have your own portal to share with the world. To learn more about your portal,
+        check out <a href="https://github.com/Rotonde/rotonde-client">the documentation</a>.
+        There you can find out more about what commands are available and how you can manage
+        your portal.
+      </p>
+    </article>
+
+    <button id="close-congrats-page" class="icon-button close" tabindex="0">
       <img src="/site/close.svg" alt="close"/>
     </button>
   </section>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 
-<link rel="stylesheet" href="dat://2714774d6c464dd12d5f8533e28ffafd79eec23ab20990b5ac14de940680a6fe/links/reset.css" />
-<link rel="stylesheet" href="dat://2714774d6c464dd12d5f8533e28ffafd79eec23ab20990b5ac14de940680a6fe/links/fonts.css" />
+<link rel="stylesheet" href="/links/reset.css" />
+<link rel="stylesheet" href="/links/fonts.css" />
 <link rel="stylesheet" href="/site/styles.css" />
 <script defer src="/site/scripts.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+
+<link rel="stylesheet" href="dat://2714774d6c464dd12d5f8533e28ffafd79eec23ab20990b5ac14de940680a6fe/links/reset.css" />
+<link rel="stylesheet" href="dat://2714774d6c464dd12d5f8533e28ffafd79eec23ab20990b5ac14de940680a6fe/links/fonts.css" />
+<link rel="stylesheet" href="/site/styles.css" />
+<script defer src="/site/scripts.js"></script>
+
+<div class="pane-view">
+  <section id="landing-page" class="pane pane--active pane--fade-left">
+    <h1>Rotonde Launchpad</h1>
+    <button id="ignition" class="button" tabindex="0">Start your own portal!</button>
+  </section>
+
+  <section id="create-portal" class="pane pane--fade-right">
+    <div class="field avatar" data-help="svg only atm">
+      <label for="avatar" tabindex="0">
+        <img src="/site/icon.svg" />
+      </label>
+      <input id="avatar" type="file" />
+    </div>
+
+    <div class="field" data-help="e.g. lord-of-corgis">
+      <input id="name" type="text" placeholder="User Name" tabindex="0" />
+    </div>
+
+    <div class="field">
+      <input id="description" type="text" placeholder="Description (Optional)" tabindex="0"/>
+    </div>
+
+    <div class="field">
+      <input id="website" type="text" placeholder="Website (Optional)" tabindex="0"/>
+    </div>
+
+    <button id="liftoff" class="button" tabindex="0">Launch!</button>
+
+    <button id="close" class="icon-button" tabindex="0">
+      <img src="/site/close.svg" alt="close"/>
+    </button>
+  </section>
+</div>

--- a/site/close.svg
+++ b/site/close.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/site/icon.svg
+++ b/site/icon.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 300 300">
+  <defs>
+    <circle id="icon-outer-circle" cx="150" cy="150" r="109"/>
+    <circle id="icon-circle" cx="109" cy="0" r="109"/>
+    <g id="icon-circle-band">
+      <use href="#icon-circle" y="286"/>
+      <use href="#icon-circle" y="260.714"/>
+      <use href="#icon-circle" y="235.429"/>
+      <use href="#icon-circle" y="210.143"/>
+      <use href="#icon-circle" y="184.857"/>
+      <use href="#icon-circle" y="159.571"/>
+      <use href="#icon-circle" y="134.286"/>
+      <use href="#icon-circle" y="109"/>
+    </g>
+  </defs>
+  <mask id="icon-outer-mask" fill="#fff">
+    <use href="#icon-outer-circle"/>
+    <circle cx="150" cy="150" r="20" fill="#000"/>
+  </mask>
+  <g fill="none" fill-rule="evenodd">
+    <use stroke="#000" stroke-width="12" href="#icon-outer-circle"/>
+    <g stroke="#000" stroke-width="6" mask="url(#icon-outer-mask)">
+      <use href="#icon-circle-band" transform="translate(41 60)" />
+      <use href="#icon-circle-band" transform="rotate(180 129.5 119)" />
+      <use href="#icon-circle-band" transform="rotate(90 99.5 139.5)" />
+      <use href="#icon-circle-band" transform="rotate(90 208 248)" />
+    </g>
+  </g>
+</svg>

--- a/site/scripts.js
+++ b/site/scripts.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const $start = document.querySelector('#start-your-portal')
-const $close = document.querySelector('#close')
 const $create = document.querySelector('#create-portal')
+const $closeCreate = document.querySelector('#close-create-portal-page')
+const $closeCongrats = document.querySelector('#close-congrats-page')
 
-$start.addEventListener('click', goToPane.bind(null, 'create-portal-form'))
-$close.addEventListener('click', goToPane.bind(null, 'landing-page'))
+$start.addEventListener('click', goToPane.bind(null, 'create-portal-page'))
 $create.addEventListener('click', createPortal)
+$closeCreate.addEventListener('click', goToPane.bind(null, 'landing-page'))
+$closeCongrats.addEventListener('click', goToPane.bind(null, 'landing-page'))
 
 // pre download the ref implementation so its ready when they fork
 const neauoire_url = "dat://2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485/"
@@ -94,6 +96,7 @@ async function createPortal () {
 
   await portal.commit();
   open(portal.url)
+  goToPane('congrats-page')
 }
 
 async function cleanArchive(archive) {

--- a/site/scripts.js
+++ b/site/scripts.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const $ignition = document.querySelector('#ignition')
+const $close = document.querySelector('#close')
+const $liftoff = document.querySelector('#liftoff')
+
+$ignition.addEventListener('click', goToPane.bind(null, 'create-portal'))
+$close.addEventListener('click', goToPane.bind(null, 'landing-page'))
+$liftoff.addEventListener('click', liftoff)
+
+// pre download the ref implementation so its ready when they fork
+const neauoire_url = "dat://2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485/"
+const neauoire_archive = new DatArchive(neauoire_url)
+const state = {
+  avatar_image: null
+}
+
+neauoire_archive.download()
+
+initPanes()
+initAvatar()
+
+function initPanes () {
+  const $active = document.querySelector('.pane-view > .pane--active')
+  goToPane($active.id)
+}
+
+function goToPane (id) {
+  const $target = document.querySelector(`.pane-view > .pane#${id}`)
+  const $others = document.querySelectorAll(`.pane-view > .pane:not(#${id})`)
+
+  $target.classList.add('pane--active')
+  for (const $input of $target.querySelectorAll('[tabindex]')) {
+    $input.setAttribute('tabindex', 0)
+  }
+
+  for (const $pane of $others) {
+    $pane.classList.remove('pane--active')
+    for (const $input of $pane.querySelectorAll('[tabindex]')) {
+      $input.setAttribute('tabindex', -1)
+    }
+  }
+}
+
+function validateName (name) {
+  const $field = document.querySelector('#name').parentNode;
+  if (!name) {
+    $field.setAttribute('data-invalid', "Name is Required")
+    return false
+  }
+
+  if (/\s/.test(name)) {
+    $field.setAttribute('data-invalid', "A name can't have white space")
+    return false
+  }
+  return true
+}
+
+async function liftoff () {
+
+  const $name = document.querySelector('#name')
+  const $description = document.querySelector('#description')
+  const $website = document.querySelector('#website')
+
+  const name = $name.value.trim();
+  const description = $description.value || "";
+  const site = $website.value || "";
+
+  if (!validateName(name)) { return; }
+
+  const launchpad_url = await DatArchive.resolveName(window.location.href)
+  const launchpad = await new DatArchive(launchpad_url)
+
+  const portal = await DatArchive.fork(neauoire_url, {
+    title: `~${name}`,
+    description,
+  })
+
+  await cleanArchive(portal)
+
+  const portal_str = {
+    name: name,
+    desc: description,
+    port: [],
+    feed: [],
+    site: site,
+    dat: portal.url
+  }
+
+  await portal.writeFile('/portal.json', JSON.stringify(portal_str));
+
+  let icon = state.avatar_image;
+  if (!icon) { icon = await launchpad.readFile('/site/icon.svg') }
+  await portal.writeFile('/media/content/icon.svg', icon);
+
+  await portal.commit();
+  open(portal.url)
+}
+
+async function cleanArchive(archive) {
+  const root = await archive.readdir('/')
+  const frozen_files = root.filter((path) => path.startsWith('frozen-'))
+
+  for (const file of frozen_files) {
+    await archive.unlink(file)
+  }
+}
+
+function initAvatar($input) {
+  const $avatar = document.querySelector('.field.avatar input[type="file"]')
+  $avatar.addEventListener('change', async () => {
+    const file = $avatar.files[0]
+    if (!validateAvatar(file)) { return; }
+    const svg = await readAvatar(file)
+    const $image = document.querySelector('.field.avatar img')
+    $image.src = svgToUrl(svg)
+    state.avatar_image = svg
+  })
+}
+
+// Am I doing this right??
+function readAvatar(file) {
+  let reader = new FileReader()
+  reader.readAsText(file)
+  return new Promise((resolve, reject) => {
+    reader.addEventListener('load', () => {
+      resolve(reader.result)
+    })
+    reader.addEventListener('error', () => {
+      reject(reader.error)
+    })
+  })
+}
+
+function svgToUrl(string) {
+  return `data:image/svg+xml;base64,${window.btoa(string)}`
+}
+
+function validateAvatar(file) {
+  const $field = document.querySelector('.field.avatar')
+  if (file.type == "image/svg+xml") {
+    $field.removeAttribute('data-invalid')
+    return true
+  } else {
+    $field.setAttribute('data-invalid', "Image must be an svg")
+    return false
+  }
+}

--- a/site/scripts.js
+++ b/site/scripts.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const $ignition = document.querySelector('#ignition')
+const $start = document.querySelector('#start-your-portal')
 const $close = document.querySelector('#close')
-const $liftoff = document.querySelector('#liftoff')
+const $create = document.querySelector('#create-portal')
 
-$ignition.addEventListener('click', goToPane.bind(null, 'create-portal'))
+$start.addEventListener('click', goToPane.bind(null, 'create-portal-form'))
 $close.addEventListener('click', goToPane.bind(null, 'landing-page'))
-$liftoff.addEventListener('click', liftoff)
+$create.addEventListener('click', createPortal)
 
 // pre download the ref implementation so its ready when they fork
 const neauoire_url = "dat://2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485/"
@@ -56,8 +56,7 @@ function validateName (name) {
   return true
 }
 
-async function liftoff () {
-
+async function createPortal () {
   const $name = document.querySelector('#name')
   const $description = document.querySelector('#description')
   const $website = document.querySelector('#website')
@@ -68,8 +67,8 @@ async function liftoff () {
 
   if (!validateName(name)) { return; }
 
-  const launchpad_url = await DatArchive.resolveName(window.location.href)
-  const launchpad = await new DatArchive(launchpad_url)
+  const client_url = await DatArchive.resolveName(window.location.href)
+  const client = await new DatArchive(client_url)
 
   const portal = await DatArchive.fork(neauoire_url, {
     title: `~${name}`,
@@ -90,7 +89,7 @@ async function liftoff () {
   await portal.writeFile('/portal.json', JSON.stringify(portal_str));
 
   let icon = state.avatar_image;
-  if (!icon) { icon = await launchpad.readFile('/site/icon.svg') }
+  if (!icon) { icon = await client.readFile('/site/icon.svg') }
   await portal.writeFile('/media/content/icon.svg', icon);
 
   await portal.commit();

--- a/site/styles.css
+++ b/site/styles.css
@@ -99,8 +99,8 @@ a[href]:hover {
   cursor: text;
   transition: border-color 200ms ease;
 }
-
-.field input[type="text"]:focus {
+.field input[type="text"]:hover:not(:active),
+.field input[type="text"]:focus:not(:active) {
   border-color: var(--black);
 }
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -30,8 +30,21 @@ p {
   margin: 1rem 0;
 }
 
+a[href] {
+  text-decoration: underline var(--grey);
+  cursor: pointer;
+}
+
+a[href]:hover {
+  text-decoration-color: var(--black);
+}
+
 #landing-page h1 {
   text-align: center;
+}
+
+#congrats-page article {
+  width: 30rem;
 }
 
 .pane {
@@ -213,7 +226,7 @@ p {
   border-color: var(--black)
 }
 
-#close {
+.close {
   position: absolute;
   top: 2rem;
   left: 2rem;

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,221 @@
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+:root {
+  --font-regular: 'input_mono_regular', monospace;
+  --font-medium: 'input_mono_medium', monospace;
+  --font-thin: 'input_mono_thin', monospace;
+  --black: #222;
+  --grey: #aaa;
+  --white: #fcfcfc;
+  --red: #d95270;
+
+  color: var(--black);
+  font-family: var(--font-regular);
+
+  font-size: 100%;
+}
+
+:root, body {
+  background-color: var(--white);
+}
+
+h1 {
+  font-family: var(--font-medium);
+  font-size: 4rem;
+}
+
+p {
+  margin: 1rem 0;
+}
+
+#landing-page h1 {
+  text-align: center;
+}
+
+.pane {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+}
+
+.pane > *+* {
+  margin-top: 1rem;
+}
+
+.pane--active {
+  opacity: 1;
+  transform: scale(1);
+  transition: opacity 400ms 400ms ease, transform 400ms 400ms ease;
+  z-index: 1;
+}
+
+.pane:not(.pane--active) {
+  opacity: 0;
+  transition: opacity 500ms ease, transform 400ms 100ms ease;
+}
+
+.pane--fade-left:not(.pane--active) {
+  transform: translateX(-1rem); 
+}
+.pane--fade-right:not(.pane--active) {
+  transform: translateX(1rem);
+}
+
+.pane-view {
+  overflow: hidden;
+  transition: margin 700ms 200ms ease;
+  position: relative;
+  height: 100vh;
+  width: 100vw;
+}
+
+.field input[type="text"] {
+  width: 100%;
+  height: 3rem;
+  border-bottom: var(--grey) solid .125rem;
+  background-color: transparent;
+  cursor: text;
+  transition: border-color 200ms ease;
+}
+
+.field input[type="text"]:focus {
+  border-color: var(--black);
+}
+
+.field input[type="text"]::placeholder {
+  color: var(--grey);
+}
+
+.field {
+  width: 20rem;
+}
+
+.field[data-invalid] input[type="text"] {
+  border-color: var(--red);
+}
+
+.field[data-help]::after,
+.field[data-invalid]::after
+{
+  display: block;
+  margin-top: .25rem;
+  font-size: .8em;
+}
+
+.field[data-help]::after {
+  content: attr(data-help);
+  color: var(--grey);
+}
+
+.field[data-invalid]::after {
+  content: attr(data-invalid);
+  color: var(--red);
+}
+
+.field.avatar {
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+}
+.field.avatar[data-invalid] label {
+  border-color: var(--red)
+}
+
+.field.avatar input[type="file"] {
+  display: none;
+}
+
+.field.avatar label {
+  position: relative;
+  height: 11.75rem;
+  width: 10rem;
+  padding: .125rem .125rem 1.75rem;
+  border: .125rem dashed var(--grey);
+  cursor: pointer;
+  transition: border-color 200ms ease;
+}
+
+.field.avatar img {
+  max-width: 100%;
+  max-height: 10rem;
+}
+
+.field.avatar label:hover:not(:active),
+.field.avatar label:focus:not(:active) {
+  border-color: var(--black);
+}
+
+.field.avatar label:hover:not(:active)::after,
+.field.avatar label:focus:not(:active)::after {
+  background-color: var(--black)
+}
+
+.field.avatar label::after {
+  position: absolute;
+  height: 1.5rem;
+  bottom: .125rem;
+  left: .125rem;
+  right: .125rem;
+  line-height: 1.5rem;
+  background-color: var(--grey);
+  color: var(--white);
+  content: "change";
+  text-align: center;
+  transition: background-color 200ms ease;
+}
+
+.button,
+.icon-button {
+  cursor: pointer;
+}
+
+.button {
+  padding: .5rem 1rem;
+  background-color: var(--black);
+  color: var(--white);
+  border: .125rem solid var(--white);
+  outline: .125rem solid transparent;
+  transition: outline-color 200ms ease;
+}
+
+.button:focus:not(:active),
+.button:hover:not(:active){
+  outline-color: var(--black);
+}
+
+.icon-button {
+  width: 2rem;
+  height: 2rem;
+  background-color: var(--white);
+  color: var(--black);
+  border-radius: 50%;
+  border: .125rem solid var(--white);
+  transition: border-color 200ms ease;
+}
+
+.icon-button img {
+  fill: var(--black);
+  width: 100%;
+  height: 100%;
+}
+
+.icon-button:hover:not(:active),
+.icon-button:focus:not(:active) {
+  border-color: var(--black)
+}
+
+#close {
+  position: absolute;
+  top: 2rem;
+  left: 2rem;
+  margin: 0;
+}


### PR DESCRIPTION
As per discussion on #117 I've gone ahead and moved the launchpad in.

@neauoire I'm not sure what all you want to do with the designs, but for conflicts sake here is what I was wanting to work on before this gets merged:

- [x] remove Launchpad terminology
- [ ] Add the Rotonde Swirl to the landing-page
- [x] Add a "congratulations" page that points the user to the documentation

Some other things that I would **eventually** like to do with the site:

- move the majority of the documentation here
- Add a "preferences" page that allows a user to update their settings in a similar fashion.
- Enable the site to fall back to https and prompt the user to download Beaker.
- Offer a selection of default avatars to choose from.