### PR TITLE
Use hashes() when checking relationships; Fix dat cmd & enhance dat, undat

### DIFF
--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -260,6 +260,9 @@ function to_hash(url)
   if (!url)
     return null;
 
+  if (url.startsWith("//"))
+    url = url.substring(2);
+
   url = url.replace("dat://", "");
 
   var index = url.indexOf("/");

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -159,8 +159,16 @@ function Operator(el)
       console.log("could not find",path)
     }
 
+    for(id in r.home.feed.portals){
+      if (!has_hash(r.home.feed.portals[id], path))
+        continue;
+      r.home.feed.portals.splice(id, 1)[0].badge_remove();
+      break;
+    }
+
     r.home.save();
     r.home.update();
+    r.home.feed.refresh("unfollowing: "+option);
   }
 
   this.commands.dat = function(p,option)
@@ -174,6 +182,8 @@ function Operator(el)
       }
     }
     r.home.portal.json.port.push("dat://"+option+"/");
+    r.home.feed.queue.push("dat://"+option+"/");
+    r.home.feed.next();
     r.home.save();
     r.home.update();
   }

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -172,6 +172,15 @@ function Portal(url)
     return this.badge_element;
   }
 
+  this.badge_remove = function() {
+    if (this.badge_element == null)
+      return;
+    // Simpler alternative than elem.parentElement.remove(elem);
+    this.badge_element.remove();
+    this.badge_element = null;
+    this.badge_element_html = null;
+  }
+
   this.badge = function(special_class)
   {
     // Avoid 'null' class.

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -122,10 +122,8 @@ function Portal(url)
     return e;
   }
 
-  this.relationship = function(target = r.home.url)
+  this.relationship = function(target = r.home.portal.hashes())
   {
-    target = to_hash(target);
-
     if (has_hash(this.json.port, target)) return "@";
 
     return "~";


### PR DESCRIPTION
This should fix finally the issue @frozenpandaman is dealing with in #16.

We'll (finally) check the portal's port list against _all_ of our hashes. A "hash" can be `1327ca6d4caf3c4665f5b82d72a5dc716ddf24f58f253e857c5703b9b6a69838` (resolved) or `elifessler.com` (the current domain name).

Latter should get resolved to the actual hash when the portal gets registered, anyway, but it will still cause issues when someone on an older version has got `elifessler.com` in their `ports` and eli is checking their portal from `1327...9898`.

We could try resolving the URLs in followed portals' `port`s, but
1. it'd strain the user's data connection even more
2. it'd cause unnecessary refreshes once we resolved it
3. it will be unnecessary once enough people move on to 1.8+ and after some time passes.

(Alternatively, check if the `dat` field in our own `portal.json` contains a "masked" URL to check against, but we're moving away from the `dat` field as it's just causing a handful of other issues...)

This PR also fixes the dat command not working properly and makes the dat and undat commands refresh the portals list and feed.