### PR TITLE
Move runes to CSS (implement #43)

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -1,3 +1,19 @@
+:root {
+  /* Variables - can be overridden by custom.css */
+  --rune-operator-message: ">";
+  --rune-operator-command: "$";
+  --rune-operator-media: "!";
+
+  --rune-feed-whisper: "&";
+  --rune-feed-quote: "+";
+  --rune-feed-mention: ":";
+
+  --rune-portal-self: "@";
+  --rune-portal-both: "@";
+  --rune-portal-follow: "~";
+  --rune-portal-bot: "$";
+}
+
 body { overflow-x:hidden; font-size:11pt; font-family: 'Helvetica Neue','Helvetica'; padding:30px; line-height:20pt; background:#eee; padding-bottom: 140px; width: 100vw; display: flex; flex-direction: column; padding: 0px;}
 t { display:inline-block; }
 hr { clear:both; }
@@ -106,3 +122,16 @@ body #operator #icon:hover { opacity: 0.5 }
 .badge:hover { background: #f4f4f4; cursor: pointer; }
 
 .badge.discovery { background:white; }
+
+.rune.rune-operator.rune-operator-message:after { content: var(--rune-operator-message); }
+.rune.rune-operator.rune-operator-command:after { content: var(--rune-operator-command); }
+.rune.rune-operator.rune-operator-media:after { content: var(--rune-operator-media); }
+
+.rune.rune-feed.rune-feed-whisper:after { content: var(--rune-feed-whisper); }
+.rune.rune-feed.rune-feed-quote:after { content: var(--rune-feed-quote); }
+.rune.rune-feed.rune-feed-mention:after { content: var(--rune-feed-mention); }
+
+.rune.rune-portal.rune-portal-self:after { content: var(--rune-portal-self); }
+.rune.rune-portal.rune-portal-both:after { content: var(--rune-portal-both); }
+.rune.rune-portal.rune-portal-follow:after { content: var(--rune-portal-follow); }
+.rune.rune-portal.rune-portal-bot:after { content: var(--rune-portal-bot); }

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -140,15 +140,15 @@ function Entry(data,host)
   this.rune = function()
   {
     if(this.whisper){
-      return "&";
+      return create_rune("feed", "whisper");
     }
     if(this.quote){
-      return "+";
+      return create_rune("feed", "quote");
     }
     if(this.target && this.target.length != 0){
       // Fun fact: this.target.length != 0 works for strings ("".length == 0),
       // but also for arrays ([].length == 0).
-      return ":";
+      return create_rune("feed", "mention");
     }
     return "";
   }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -316,4 +316,11 @@ function portal_from_hash(url)
   return hash.substr(0,12)+".."+hash.substr(hash.length-3,2);
 }
 
+function create_rune(context, type)
+{
+  context = r.escape_attr(context);
+  type = r.escape_attr(type);
+  return `<i class='rune rune-${context} rune-${context}-${type}'></i>`;
+}
+
 r.confirm("script","feed");

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -48,15 +48,18 @@ function Operator(el)
 
     this.hint_el.innerHTML = this.autocomplete_words().length > 0 ? this.autocomplete_words()[0] : chars+"C "+words+"W";
     this.hint_el.className = this.autocomplete_words().length > 0 ? "autocomplete" : "";
-    this.rune_el.innerHTML = ">";
-    this.rune_el.className = input.length > 0 ? "input" : "";
 
+    this.rune_el.innerHTML = "";
+    this.rune_el.className = "rune rune-operator";
     if(this.keywords.indexOf(input.split(" ")[0]) > -1 || input.indexOf(":") > -1){
-      this.rune_el.innerHTML = "$";
+      this.rune_el.className += " rune-operator-command";
+    } else if(input.indexOf(">>") > -1){
+      this.rune_el.className += " rune-operator-media";
+    } else {
+      this.rune_el.className += " rune-operator-message";
     }
-    if(input.indexOf(">>") > -1){
-      this.rune_el.innerHTML = "!";
-    }
+
+    this.rune_el.className += input.length > 0 ? " input" : "";
   }
 
   this.validate = function()

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -124,9 +124,10 @@ function Portal(url)
 
   this.relationship = function(target = r.home.portal.hashes())
   {
-    if (has_hash(this.json.port, target)) return "@";
+    if (has_hash(this, target)) return create_rune("portal", "self");
+    if (has_hash(this.json.port, target)) return create_rune("portal", "both");
 
-    return "~";
+    return create_rune("portal", "follow");
   }
 
   this.updated = function()


### PR DESCRIPTION
This implements #43, changing the runes from hardcoded ones to CSS variables.

Runes are split into "contexts" so you can manipulate all runes of one kind at once (f.e. all portal runes).

Effectively, rune elements have the following three classes:
* `rune` - matches all runes
* `rune-{context}` - matches f.e. all operator runes, feed runes, portal runes
* `rune-{context}-{type}` - this is also the variable name, allowing you to manipulate runes from custom.css as you wish