### PR TITLE
Add promiseTimeout helper and make discovery "opt-in"

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -71,6 +71,10 @@ body #feed .entry.paginator { padding: 0; }
 body #feed .entry.paginator .message { margin: 16px 0 0 0; font-size: 16px; line-height: 40px; }
 body #feed .badge.paginator .message { margin: 50px auto; font-size: 16px; text-decoration: none; pointer-events: none; }
 
+body #feed .badge.paginator.refresh .message { transition: opacity 0.2s; }
+body #feed .badge.paginator.refreshing { cursor: default; }
+body #feed .badge.paginator.refreshing .message { opacity: 0.5; }
+
 #wr_timeline { display: block; padding-bottom: 50px; }
 #wr_portals { display: none; background:white;}
 #wr_discovery { display: none; background: white; }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -245,7 +245,7 @@ function Feed(feed_urls)
     r.home.feed.tab_mentions_el.innerHTML = this.mentions+" Mention"+(this.mentions == 1 ? '' : 's')+"";
     r.home.feed.tab_whispers_el.innerHTML = this.whispers+" Whisper"+(this.whispers == 1 ? '' : 's')+"";
     r.home.feed.tab_portals_el.innerHTML = r.home.feed.portals.length+" Portal"+(r.home.feed.portals.length == 1 ? '' : 's')+"";
-    r.home.feed.tab_discovery_el.innerHTML = r.home.discovered_count+"/"+r.home.network.length+" Network"+(r.home.network.length == 1 ? '' : 's')+"";
+    r.home.feed.tab_discovery_el.innerHTML = (r.home.discovery_enabled?r.home.discovered_count+"/":"")+r.home.network.length+" Network"+(r.home.network.length == 1 ? '' : 's')+"";
 
     r.home.feed.tab_mentions_el.className = r.home.feed.target == "mentions" ? "active" : "";
     r.home.feed.tab_whispers_el.className = r.home.feed.target == "whispers" ? "active" : "";
@@ -268,7 +268,7 @@ function to_hash(url)
   var index = url.indexOf("/");
   url = index == -1 ? url : url.substring(0, index);
 
-  url = url.trim();
+  url = url.toLowerCase().trim();
   return url;
 }
 

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -286,6 +286,7 @@ function Operator(el)
       page = 0;
     r.home.feed.page_jump(page);
   }
+
   this.commands.help = function(p, option) {
       if (p === '' || p == null)
         p = option;
@@ -323,6 +324,11 @@ function Operator(el)
           }
       }
   }
+
+  this.commands.discovery_refresh = function(p, option) {
+    r.home.discover();
+  }
+
   this.autocomplete_words = function()
   {
     var words = r.operator.input_el.value.split(" ");

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -47,7 +47,7 @@ function Portal(url)
     console.log('connecting to: ', p.url);
 
     try {
-      p.file = await p.archive.readFile('/portal.json', {timeout: 2000});
+      p.file = await promiseTimeout(p.archive.readFile('/portal.json', {timeout: 2000}), 2000);
     } catch (err) {
       console.log('connection failed: ', p.url);
       r.home.feed.next();
@@ -69,7 +69,7 @@ function Portal(url)
     console.log('connecting to: ', p.url);
 
     try {
-      p.file = await p.archive.readFile('/portal.json', {timeout: 2000});
+      p.file = await promiseTimeout(p.archive.readFile('/portal.json', {timeout: 2000}), 2000);
     } catch (err) {
       console.log('connection failed: ', p.url);
       r.home.discover_next();
@@ -91,7 +91,7 @@ function Portal(url)
   {
     try {
       console.log("refreshing: ",p.url)
-      p.file = await p.archive.readFile('/portal.json',{timeout: 1000});
+      p.file = await promiseTimeout(p.archive.readFile('/portal.json',{timeout: 1000}), 1000);
     } catch (err) {
       console.log("connection failed: ",p.url)
       return;
@@ -252,6 +252,22 @@ function Portal(url)
 
     return false;
   }
+}
+
+function promiseTimeout(promise, timeout) {
+  return new Promise((resolve, reject) => {
+    var rejectout = setTimeout(() => reject(new Error("Promise hanging, timeout!")), timeout);
+    promise.then(
+      function() {
+        clearTimeout(rejectout);        
+        resolve.apply(this, arguments);
+      },
+      function() {
+        clearTimeout(rejectout);        
+        reject.apply(this, arguments);
+      }
+    );
+  });
 }
 
 r.confirm("script","portal");


### PR DESCRIPTION
* I added a small function to help us deal with timeouts not working properly in Beaker pre-0.8. You call it similarly to `setTimeout`, but passing on the promise to wait for instead of a function to run after the timeout. Example: `await promiseTimeout(p.archive.readFile('/portal.json', {timeout: 2000}), 2000);` (`{timeout: 2000}` kept as-is to rely on Beaker 0.8's timeout in the future.)
* The discovery tab now doesn't update in the background, but instead requires the user to press a new "refresh" button (always the first entry). I've also fixed it being too fast and thus consuming too many resources in a too short timespan.