### PR TITLE
Fix media URI escape issue + some putting "media/content/" into their media URLs

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -121,8 +121,12 @@ function Entry(data,host)
       var media = this.media;
       if (media.startsWith("/"))
         media = media.substring(1);
+      else if (media.startsWith("%2F"))
+        media = media.substring(3);
       if (media.startsWith("media/content/"))
         media = media.substring("media/content/".length);
+      else if (media.startsWith("media%2Fcontent%2F"))
+        media = media.substring("media%2Fcontent%2F".length);
       var parts = media.split(".")
       extension = parts[parts.length-1].toLowerCase();
       if (parts.length === 1) {

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -116,11 +116,17 @@ function Entry(data,host)
   {
     var html = "";
     if(this.media){
-      this.media = encodeURI(this.media);
-      var parts = this.media.split(".")
+      // We hope that the URI's already encoded.
+      // We can't encode it here as that'd break previously encoded URIs (see: operator.commands.say).
+      var media = this.media;
+      if (media.startsWith("/"))
+        media = media.substring(1);
+      if (media.startsWith("media/content/"))
+        media = media.substring("media/content/".length);
+      var parts = media.split(".")
       extension = parts[parts.length-1].toLowerCase();
       if (parts.length === 1) {
-        this.media += ".jpg";
+        media += ".jpg";
         extension = "jpg";
       } // support og media uploads
       audiotypes = ["m4a", "mp3", "oga", "ogg", "opus"];
@@ -129,10 +135,10 @@ function Entry(data,host)
 
       var origin = this.quote && this.target ? this.target : this.host.url;
 
-      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"/media/content/"+this.media+"' controls />"; }
-      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"/media/content/"+this.media+"' controls />"; }
-      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"/media/content/"+this.media+"'/>"; }
-      else{ html +="<a class='media' href='"+origin+"/media/content/"+this.media+"'>&gt;&gt; "+this.media+"</a>"; }
+      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"/media/content/"+media+"' controls />"; }
+      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"/media/content/"+media+"' controls />"; }
+      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"/media/content/"+media+"'/>"; }
+      else{ html +="<a class='media' href='"+origin+"/media/content/"+media+"'>&gt;&gt; "+media+"</a>"; }
     }
     return html;
   }

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -103,6 +103,8 @@ function Operator(el)
     // Rich content
     if(message.indexOf(" >> ") > -1){
       // encode the file names to allow for odd characters, like spaces
+      // Encoding the URI needs to happen here.
+      // We can't encode it in entry.rmc as that'd break previously encoded URIs.
       media = encodeURIComponent(message.split(" >> ")[1].trim());
       message = message.split(" >> ")[0].trim();
     }


### PR DESCRIPTION
This fixes the following two issues, both outlined in this comment: https://github.com/Rotonde/rotonde-client/issues/109#issuecomment-343909738

* The media URLs in `portal.json` are already sent through `encodeURIComponent` (shouldn't they be sent through `encodeURI`?). Meanwhile, `entry.rmc` sends them through `encodeURI` *again* and stores the encoded URI as `this.media`, causing an escaping "feedback loop". Thanks to @eelfroth for telling me about this!
* Some accidentally added `media/content/` (escaped: `media%2Fcontent%2F`) to their media URLs. As it's an easy mistake and easy to fix on our end, this PR fixes the "issue" by removing the improperly added prefix from media URLs.

Thank you @eelfroth for notifying me about this!