### PR TITLE
threads! (+ some fixes)

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -104,7 +104,7 @@ body #feed.portals #tab_discovery {}
 
 .hidden { display: none; }
 
-body #operator { position: sticky;overflow: hidden;z-index: 500;font-family: "input_mono_regular";margin: 0px auto;min-width: 400px;width: 100vw;top: 0px;background: #fff;z-index: 999;padding: 5px 0px;box-shadow: 0px 0px 2px rgba(0,0,0,0.15);}
+body #operator { position: fixed; top: 0px;overflow: hidden;z-index: 500;font-family: "input_mono_regular";margin: 0px auto;min-width: 400px;width: 100vw;top: 0px;background: #fff;z-index: 999;padding: 5px 0px;box-shadow: 0px 0px 2px rgba(0,0,0,0.15);}
 body #operator textarea { display: flex; color: white; width: 100%; align-content: center; height: 20px; resize: none; max-height: 100px; background: transparent; align-self: center; transition: all 150ms; line-height: 22px; min-height:20px; color:#000;padding-left: 15px;}
 body #operator textarea.drag { background: #b7b7b7; }
 body #operator textarea::-webkit-scrollbar { display: none; }

--- a/links/main.css
+++ b/links/main.css
@@ -43,7 +43,13 @@ body #feed .entry .message a { text-decoration: underline; }
 body #feed .entry .message b { font-weight: bold }
 body #feed .entry .message i { font-style: italic; }
 body #feed .entry .message del { text-decoration: line-through; }
-body #feed .entry .message.quote { padding:0px 40px; color:#777; margin-top:15px; margin-bottom:10px; font-size:11pt; font-style: italic}
+body #feed .entry .thread .message { padding:0px 40px; color:#777; margin-top:15px; margin-bottom:10px; font-size:11pt; font-style:italic}
+body #feed .entry .thread .expand { padding:5px 15px; font-size:10pt; color:#aaa; }
+body #feed .entry .thread .expand:hover { text-decoration:underline; color:#000; cursor:pointer; }
+body #feed .entry .thread .entry { background:transparent; padding-top:10px; padding-bottom:0px; }
+body #feed .entry .thread .entry:hover { background:#fff; }
+body #feed .entry .thread .entry .message { padding:0px 0px; margin-top:0px; }
+body #feed .entry .thread .entry .icon { width:50px; height:50px; }
 body #feed .entry .message .highlight { font-weight: bold; color:#555; line-height: 25px; }
 body #feed .entry .message .inline { display: inline-block; margin: 6px 4px -6px 4px; height: 24px; }
 body #feed .entry .portal { margin-right:15px;  display:inline-block; margin-top:10px; font-weight: bold; margin-bottom:5px;}

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -128,11 +128,12 @@ function Entry(data,host)
       imagetypes = ["apng", "gif", "jpg", "jpeg", "jpe", "png", "svg", "svgz", "tiff", "tif", "webp"];
 
       var origin = this.quote && this.target ? this.target : this.host.url;
+      origin += origin.toString().slice(-1) == "/" ? "" : "/";
 
-      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"/media/content/"+this.media+"' controls />"; }
-      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"/media/content/"+this.media+"' controls />"; }
-      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"/media/content/"+this.media+"'/>"; }
-      else{ html +="<a class='media' href='"+origin+"/media/content/"+this.media+"'>&gt;&gt; "+this.media+"</a>"; }
+      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"media/content/"+this.media+"' controls />"; }
+      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"media/content/"+this.media+"' controls />"; }
+      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"media/content/"+this.media+"'/>"; }
+      else{ html +="<a class='media' href='"+origin+"media/content/"+this.media+"'>&gt;&gt; "+this.media+"</a>"; }
     }
     return html;
   }
@@ -251,7 +252,8 @@ function Entry(data,host)
       var right = m.substring(ir + 2);
 
       var origin = this.quote && this.target ? this.target : this.host.url;
-      var src = origin + '/media/content/inline/' + mid;
+      origin += origin.toString().slice(-1) == "/" ? "" : "/";
+      var src = origin + 'media/content/inline/' + mid;
 
       if (src.indexOf('.') == -1) {
           src = src + '.png'; // Default extension: .png

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -3,7 +3,6 @@ function Entry(data,host)
   this.host = host;
 
   this.message = data.message;
-  this.quote = data.quote;
   this.ref = data.ref;
   this.timestamp = data.timestamp;
   this.id = data.id;
@@ -11,6 +10,13 @@ function Entry(data,host)
   this.media = data.media;
   this.target = data.target;
   this.whisper = data.whisper;
+
+  if(this.target && !(this.target instanceof Array)){
+    if(this.target.dat){ this.target = [this.target.dat]; }
+    else{ this.target = [this.target ? this.target : ""]; }
+  }
+
+  this.quote = data.quote && this.target ? new Entry(data.quote, {"url": this.target[0]}) : null;
 
   this.is_seed = this.host ? r.home.portal.json.port.indexOf(this.host.url) > -1 : false;
 
@@ -107,8 +113,8 @@ function Entry(data,host)
   this.body = function()
   {
     var html = "";
-    html += "<t class='message' dir='auto'>"+(this.formatter(this.message))+"</t><br/>";
-    if(this.quote){ html += "<t class='message quote' dir='auto'>"+(this.formatter(this.quote.message))+"</t><br/>"; }
+    html += "<t class='message' dir='auto'>"+(this.formatter(this.message, this))+"</t><br/>";
+    if(this.quote){ html += "<t class='message quote' dir='auto'>"+(this.formatter(this.quote.message, this.quote))+"</t><br/>"; }
     return html;
   }
 
@@ -154,9 +160,9 @@ function Entry(data,host)
     return "";
   }
 
-  this.formatter = function(message)
+  this.formatter = function(message, entry)
   {
-    return message.split(/\r\n|\n/).map(this.format_line, this).join("<br>");
+    return message.split(/\r\n|\n/).map(this.format_line, entry).join("<br>");
   }
 
   this.format_line = function(m)
@@ -251,8 +257,8 @@ function Entry(data,host)
       var mid = m.substring(il + 2, ir);
       var right = m.substring(ir + 2);
 
-      var origin = this.quote && this.target ? this.target : this.host.url;
-      origin += origin.toString().slice(-1) == "/" ? "" : "/";
+      var origin = this.host.url;
+      origin += origin.slice(-1) == "/" ? "" : "/";
       var src = origin + 'media/content/inline/' + mid;
 
       if (src.indexOf('.') == -1) {
@@ -299,14 +305,6 @@ function Entry(data,host)
   {
     var im = false;
     if(this.target){
-      if(!(this.target instanceof Array)){
-          if(this.target.dat) {
-            this.target = [this.target.dat];
-          } else {
-            this.target = [this.target ? this.target : ""];
-          }
-      }
-
       // Mention tag, eg '@dc'
       const mentionTag = '@' + r.home.portal.json.name
       const msg = this.message.toLowerCase()

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -174,10 +174,10 @@ function Entry(data,host)
       var origin = this.quote && this.target ? this.target : this.host.url;
       origin += origin.toString().slice(-1) == "/" ? "" : "/";
 
-      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"media/content/"+this.media+"' controls />"; }
-      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"media/content/"+this.media+"' controls />"; }
-      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"media/content/"+this.media+"'/>"; }
-      else{ html +="<a class='media' href='"+origin+"media/content/"+this.media+"'>&gt;&gt; "+this.media+"</a>"; }
+      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"media/content/"+media+"' controls />"; }
+      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"media/content/"+media+"' controls />"; }
+      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"media/content/"+media+"'/>"; }
+      else{ html +="<a class='media' href='"+origin+"media/content/"+media+"'>&gt;&gt; "+media+"</a>"; }
     }
     return html;
   }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -159,7 +159,7 @@ function Feed(feed_urls)
       return;
     }    
     if(!why) { console.error("unjustified refresh"); }
-    console.log("refreshing feed…", "#" + r.home.feed.target, "→"+why);
+    console.log("refreshing feed..", "#" + r.home.feed.target, "→"+why);
 
     if (this.page_target != r.home.feed.target ||
         this.page_filter != r.home.feed.filter) {

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -329,6 +329,35 @@ function Operator(el)
     r.home.discover();
   }
 
+  this.commands.expand = function(p, option)
+  {
+    var name = option.split("-")[0];
+    var ref = parseInt(option.split("-")[1]);
+
+    var portals = r.operator.lookup_name(name);
+
+    if(portals.length === 0 || !portals[0].json.feed[ref]){
+      return;
+    }
+
+    if(portals[0].expanded.indexOf(ref) < 0){ portals[0].expanded.push(ref+""); }
+  }
+
+  this.commands.collapse = function(p, option)
+  {
+    var name = option.split("-")[0];
+    var ref = parseInt(option.split("-")[1]);
+
+    var portals = r.operator.lookup_name(name);
+
+    if(portals.length === 0 || !portals[0].json.feed[ref]){
+      return;
+    }
+
+    var index = portals[0].expanded.indexOf(ref+"");
+    if(index > -1){ portals[0].expanded.splice(index, 1); }
+  }
+
   this.autocomplete_words = function()
   {
     var words = r.operator.input_el.value.split(" ");

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -378,8 +378,6 @@ function Operator(el)
 
   this.key_down = function(e)
   {
-    var scroll = document.body.scrollTop;
-
     if(e.key == "Enter" && !e.shiftKey){
       e.preventDefault();
       r.operator.validate();
@@ -444,7 +442,6 @@ function Operator(el)
     }
 
     r.operator.update();
-    setTimeout(window.scrollTo, 1, 0, scroll);
   }
 
   this.input_changed = function(e)

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -20,6 +20,8 @@ function Portal(url)
   // Cache entries when possible.
   this.cache_entries = {};
 
+  this.expanded = [];
+
   this.start = async function()
   {
     var file = await this.archive.readFile('/portal.json',{timeout: 2000}).then(console.log("done!"));
@@ -116,6 +118,7 @@ function Portal(url)
         this.cache_entries[raw.timestamp] = entry = new Entry(this.json.feed[id], p);
       entry.id = id;
       entry.is_mention = entry.detect_mention();
+      entry.expanded = this.expanded.indexOf(id+"") > -1;
       e.push(entry);
     }
     this.last_entry = e[p.json.feed.length - 1];


### PR DESCRIPTION
ok, this is kind of a big PR so let me briefly explain each commit.

`da007da`: I noticed that sometimes media attachment URLs had a superfluous `/` and couldn't be displayed because of that → fixed!

`a7b8c0b`: when you quoted a message that has inline emoji, the client looked for the images in the quoter's portal (not the quotee's) → fixed!

`372f75a`: this introduces rendering of quote-threads! if there is more than one quote (as in, the quote has a quote, etc.), a "expand `n` quotes" message appears. clicking it will validate `expand:name-ref`, and the thread will be shown. clicking "collapse quotes" on an expanded thread will validate `collapse:name-ref`, and the thread is hidden once more. threads → implemented!

`5180280`: this re-fixes the issue that you would lose your scroll position when you typed in the operator input field, but with pure CSS. the hacky JS solution I made before had introduced some ugly flickering → fixed!