### PR TITLE
Potential fix for disappearing tabs on discovery and portals pages

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -84,8 +84,8 @@ body #feed .badge.paginator.refreshing { cursor: default; }
 body #feed .badge.paginator.refreshing .message { opacity: 0.5; }
 
 #wr_timeline { display: block; padding-bottom: 50px; }
-#wr_portals { display: none; background:white;}
-#wr_discovery { display: none; background: white; }
+#wr_portals { display: none; padding-bottom: 50px; }
+#wr_discovery { display: none; padding-bottom: 50px; }
 
 body #feed.mentions .entry.mention { display: block }
 


### PR DESCRIPTION
hey this is a quick solution I found to the disappearing tabs issue.
the fix works for me and the handful of other portals I tried it on but can't guarantee it won't break someones styling somewhere

for reference - my portal: dat://a5341c28d55680dfbe073df05a01e9d58591a782e5ca252d60b2ce62935b4498/

hope random pull requests are okay!