### PR TITLE
Sort port list by activity, fix portal.updated(), misc fixes

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -32,10 +32,7 @@ function Entry(data,host)
   {
     if (c < cmin || cmax <= c) {
       // Out of bounds - remove if existing, don't add.
-      if (this.element != null)
-          timeline.removeChild(this.element);
-      this.element = null;
-      this.element_html = null;
+      this.remove_element();
       return null;
     }
 
@@ -52,6 +49,15 @@ function Entry(data,host)
     // Always append as last.
     timeline.appendChild(this.element);
     return this.element;
+  }
+
+  this.remove_element = function() {
+    if (this.element == null)
+      return;
+    // Simpler alternative than elem.parentElement.remove(elem);
+    this.element.remove();
+    this.element = null;
+    this.element_html = null;
   }
 
   this.to_json = function()

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -1,29 +1,33 @@
 function Entry(data,host)
 {
-  this.host = host;
-
-  this.message = data.message;
-  this.ref = data.ref;
-  this.timestamp = data.timestamp;
-  this.id = data.id;
-  this.editstamp = data.editstamp;
-  this.media = data.media;
-  this.target = data.target;
-  this.whisper = data.whisper;
-
-  if(this.target && !(this.target instanceof Array)){
-    if(this.target.dat){ this.target = [this.target.dat]; }
-    else{ this.target = [this.target ? this.target : ""]; }
-  }
-
-  this.quote = data.quote;
-  if(data.quote && this.target && this.target[0]){
-    var dummy_portal = {"url":this.target[0],"json":{"name":r.escape_html(portal_from_hash(this.target[0].toString())).substring(1)}};
-    this.quote = new Entry(data.quote, dummy_portal);
-  }
   this.expanded = false;
-
-  this.is_seed = this.host ? r.home.portal.json.port.indexOf(this.host.url) > -1 : false;
+  
+  this.update = function(data, host) {
+    this.host = host;
+  
+    this.message = data.message;
+    this.ref = data.ref;
+    this.timestamp = data.timestamp;
+    this.id = data.id;
+    this.editstamp = data.editstamp;
+    this.media = data.media;
+    this.target = data.target;
+    this.whisper = data.whisper;
+  
+    if(this.target && !(this.target instanceof Array)){
+      if(this.target.dat){ this.target = [this.target.dat]; }
+      else{ this.target = [this.target ? this.target : ""]; }
+    }
+  
+    this.quote = data.quote;
+    if(data.quote && this.target && this.target[0]){
+      var dummy_portal = {"url":this.target[0],"json":{"name":r.escape_html(portal_from_hash(this.target[0].toString())).substring(1)}};
+      this.quote = new Entry(data.quote, dummy_portal);
+    }
+  
+    this.is_seed = this.host ? r.home.portal.json.port.indexOf(this.host.url) > -1 : false;
+  }
+  this.update(data, host);
 
   this.element = null;
   this.element_html = null;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -54,6 +54,8 @@ function Feed(feed_urls)
   this.page_target = null;
   this.page_filter = null;
 
+  this.entries_prev = [];
+
   this.install = function()
   {
     r.el.appendChild(r.home.feed.el);
@@ -213,6 +215,7 @@ function Feed(feed_urls)
     }
 
     var now = new Date();
+    var entries_now = [];
     for (id in sorted_entries){
       var entry = sorted_entries[id];
       var c = ca;
@@ -221,9 +224,21 @@ function Feed(feed_urls)
       else if (!entry.is_visible(r.home.feed.filter, r.home.feed.target))
         c = -2;
       var elem = !entry ? null : entry.to_element(timeline, c, cmin, cmax);
+      if (elem != null) {
+        entries_now.push(entry);
+      }
       if (c >= 0)
         ca++;
     }
+
+    // Remove any "zombie" entries - removed entries not belonging to any portal.
+    for (id in this.entries_prev) {
+      var entry = this.entries_prev[id];
+      if (entries_now.indexOf(entry) > -1)
+        continue;
+      entry.remove_element();
+    }
+    this.entries_prev = entries_now;
 
     var pages = Math.ceil(ca / this.page_size);
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -173,11 +173,19 @@ function Feed(feed_urls)
     this.page_filter = r.home.feed.filter;
 
     var entries = [];
+    var portals_updated = {};
 
-    for(id in r.home.feed.portals){
+    for(var id in r.home.feed.portals){
       var portal = r.home.feed.portals[id];
-      entries = entries.concat(portal.entries())
+      entries = entries.concat(portal.entries());
+      portals_updated[portal.url] = portal.updated();
     }
+
+    r.home.portal.json.port = r.home.portal.json.port.sort((a, b) => {
+      a = portals_updated[a] || 0;
+      b = portals_updated[b] || 0;
+      return b - a;
+    });
 
     this.mentions = entries.filter(function (e) { return e.is_visible("", "mentions") }).length
     this.whispers = entries.filter(function (e) { return e.is_visible("", "whispers") }).length

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -103,9 +103,11 @@ function Feed(feed_urls)
     this.portals.push(portal);
     var activity = portal.archive.createFileActivityStream();
     activity.addEventListener("invalidated", e => {
+      if (e.path != '/portal.json')
+        return;
       portal.refresh().then(() => {
         r.home.update();
-        r.home.feed.refresh(portal.json.name+" refreshed");
+        r.home.feed.refresh(portal.json.name+" updated");
       });
     });
     r.home.update();

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -173,19 +173,11 @@ function Feed(feed_urls)
     this.page_filter = r.home.feed.filter;
 
     var entries = [];
-    var portals_updated = {};
 
     for(var id in r.home.feed.portals){
       var portal = r.home.feed.portals[id];
       entries = entries.concat(portal.entries());
-      portals_updated[portal.url] = portal.updated();
     }
-
-    r.home.portal.json.port = r.home.portal.json.port.sort((a, b) => {
-      a = portals_updated[a] || 0;
-      b = portals_updated[b] || 0;
-      return b - a;
-    });
 
     this.mentions = entries.filter(function (e) { return e.is_visible("", "mentions") }).length
     this.whispers = entries.filter(function (e) { return e.is_visible("", "whispers") }).length

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -190,6 +190,17 @@ function Home()
       await archive.writeFile('/frozen-'+(Date.now())+'.json', JSON.stringify(old, null, 2));
     }
 
+    var portals_updated = {};
+    for(var id in r.home.feed.portals){
+      var portal = r.home.feed.portals[id];
+      portals_updated[portal.url] = portal.updated();
+    }
+    r.home.portal.json.port = r.home.portal.json.port.sort((a, b) => {
+      a = portals_updated[a] || 0;
+      b = portals_updated[b] || 0;
+      return b - a;
+    });
+
     await archive.writeFile('/portal.json', JSON.stringify(this.portal.json, null, 2));
     await archive.commit();
 

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -150,7 +150,6 @@ function Operator(el)
     }
 
     r.home.save();
-    r.home.update();
   }
 
   this.commands.undat = function(p,option)
@@ -177,7 +176,6 @@ function Operator(el)
     }
 
     r.home.save();
-    r.home.update();
     r.home.feed.refresh("unfollowing: "+option);
   }
 
@@ -195,7 +193,6 @@ function Operator(el)
     r.home.feed.queue.push("dat://"+option+"/");
     r.home.feed.next();
     r.home.save();
-    r.home.update();
   }
 
   this.commands.delete = function(p,option)
@@ -240,7 +237,6 @@ function Operator(el)
     r.home.add_entry(new Entry(data));
 
     r.home.save();
-    r.home.update();
   }
 
   this.commands.whisper = function(p,option)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -171,7 +171,9 @@ function Operator(el)
     for(id in r.home.feed.portals){
       if (!has_hash(r.home.feed.portals[id], path))
         continue;
-      r.home.feed.portals.splice(id, 1)[0].badge_remove();
+      var portal = r.home.feed.portals.splice(id, 1)[0];
+      portal.badge_remove();
+      portal.entries_remove();
       break;
     }
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -138,7 +138,16 @@ function Portal(url)
     if(this.json == null || this.json.feed == null){ return 0; }
     if(this.json.feed.length < 1){ return 0; }
 
-    return p.json.feed[p.json.feed.length-1].timestamp;
+    var max = 0;
+    for (var id in this.json.feed) {
+      var entry = this.json.feed[id];
+      var timestamp = entry.editstamp || entry.timestamp;
+      if (timestamp < max)
+          continue;
+        max = timestamp;
+    }
+
+    return max;
   }
 
   this.time_offset = function() // days

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -116,7 +116,8 @@ function Portal(url)
       var entry = this.cache_entries[raw.timestamp];
       if (entry == null)
         this.cache_entries[raw.timestamp] = entry = new Entry(this.json.feed[id], p);
-      // TODO: Create a new entry anyway, but move over the element and its state.
+      else
+        entry.update(this.json.feed[id], p);
       entry.id = id;
       entry.is_mention = entry.detect_mention();
       entry.expanded = this.expanded.indexOf(id+"") > -1;

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -116,6 +116,7 @@ function Portal(url)
       var entry = this.cache_entries[raw.timestamp];
       if (entry == null)
         this.cache_entries[raw.timestamp] = entry = new Entry(this.json.feed[id], p);
+      // TODO: Create a new entry anyway, but move over the element and its state.
       entry.id = id;
       entry.is_mention = entry.detect_mention();
       entry.expanded = this.expanded.indexOf(id+"") > -1;
@@ -123,6 +124,13 @@ function Portal(url)
     }
     this.last_entry = e[p.json.feed.length - 1];
     return e;
+  }
+
+  this.entries_remove = function() {
+    var entries = this.entries();
+    for (var id in entries) {
+      entries[id].remove_element();
+    }
   }
 
   this.relationship = function(target = r.home.portal.hashes())
@@ -159,10 +167,7 @@ function Portal(url)
   {
     if (c !== undefined && (c < cmin || cmax <= c)) {
       // Out of bounds - remove if existing, don't add.
-      if (this.badge_element != null)
-          container.removeChild(this.badge_element);
-      this.badge_element = null;
-      this.badge_element_html = null;
+      this.badge_remove();
       return null;
     }
 


### PR DESCRIPTION
`portal.updated()` now correctly checks for the most recent entry (both timestamp and editstamp-wise). Before, it just blindly picked the last entry in the list.

Also, `json.port` gets sorted by activity on `home.save`.

I initially thought about sorting it in `feed.register`, but opted against it. Feeds can update on the fly and the order determined in `feed.register` can already be outdated when saving.  
Additionally, this doesn't "magically fix" your portal.json. You still need to invoke a save by f.e. following someone or posting something. Automatically invoking a save after sorting would just bloat the history.

Edit: Yet again, I'm smuggling in an unrelated fix. When using the undat command, entries from the unfollowed portal still ghosted around. This PR introduces `portal.entries_remove()` (named after `portal.entries`) invoking `element.remove_element()` (named after `element.to_element()`).

Edit 2: And two more fixes: Remove zombie entries from the feed (entries without any containing portal) and handle entry updates properly again (add `entry.update(data, host)`).