### PR TITLE
improve link shortening & add [descriptive](https://links)

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -267,7 +267,11 @@ function Entry(data,host)
         n.push(word)
       }
     }
-    return n.join(" ").trim();
+    m = n.join(" ").trim();
+    // formats descriptive [md style](https://guides.github.com/features/mastering-markdown/#examples) links
+    return m.replace(/\[(.*?)\]\((.*?)\)/g, 
+      function replacer(m, p1, p2) { return `<a href="${p2}">${p1}</a>`}
+    )
   }
 
   this.highlight_portal = function(m)

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -252,7 +252,11 @@ function Entry(data,host)
       else if (word.search(/^https?:\/\//) != -1) {
         try {
           var url = new URL(word)
-          var compressed = word.substr(word.indexOf("://")+3,url.hostname.length + 15)+"..";
+          var cutoffLen = url.hostname.length + 15;
+          var compressed = word.substr(word.indexOf("://")+3);
+          if (compressed.length > cutoffLen) {
+            compressed = compressed.substr(0, cutoffLen)+"..";
+          }
           n.push("<a href='"+url.href+"'>"+compressed+"</a>");
         } catch(e) {
           console.error("Error when parsing url:", word, e);


### PR DESCRIPTION
this pr fixes shortening of already short http links (i.e. stops appending of .. to short links)

it also makes it possible to link [passages](http://www.dictionary.com/browse/passage) of text using `[markdown style](https://guides.github.com/features/mastering-markdown/#examples)`

i'm doing this as a pr since it's been a subjective while since i last contributed, and the previous time i made a patch with regexes turned out, ehm, sub-optimal. 

potential concerns! the (url) regex isn't strict at all, so you can basically `[link](whatever)`
i'm not sure how much of a problem that will pose, i don't think it should allow for executing javascript since we escape the html before we even get to this stage

anyway i think this feature will be great for **The Daily Descent** among other things :~