### PR TITLE
small fix for displaying entries with missing desc

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -89,7 +89,7 @@ function Entry(data,host)
   this.icon = function()
   {
     var title = r.escape_html(this.host.json.name);
-    var desc = r.escape_html(this.host.json.desc);
+    var desc = r.escape_html(this.host.json.desc || "");
     if (desc){
         title += "\n" + desc;
     }


### PR DESCRIPTION
Some portals don't have a "desc" field for whatever reason (I think they're broken/not loading correctly), which breaks rendering of the feed. This is a workaround for that.