### PR TITLE
Fix escape_html / escape_attr failing on !m

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -66,7 +66,7 @@ function Rotonde(client_url)
 
   this.escape_html = function(m)
   {
-    return m
+    return m && m
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
@@ -77,7 +77,7 @@ function Rotonde(client_url)
   this.escape_attr = function(m)
   {
     // This assumes that all attributes are wrapped in '', never "".
-    return m
+    return m && m
       .replace(/'/g, "&#039;");
   }
 


### PR DESCRIPTION
This fixes threads not expanding. `entry.icon` tries to escape the host's description, which isn't set in the pseudo portal. `escape_html` and `escape_attr` threw an exception if `!m` (i.e. `m == null`).

TIL: `&&` returns the first falsy value (`"" && 0 && null` returns `""`).