### PR TITLE
Optimize a bunch of stuff

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -86,14 +86,13 @@ body #feed .badge.paginator.refreshing .message { opacity: 0.5; }
 
 #wr_timeline { display: block; padding-bottom: 50px; }
 #wr_portals { display: none; padding-bottom: 50px; }
-#wr_discovery { display: none; padding-bottom: 50px; }
 
 body #feed.mentions .entry.mention { display: block }
 
-body #feed.portals #wr_portals { display: block }
-body #feed.portals #wr_timeline { display: none; }
+body #feed.portals #wr_portals,
+body #feed.discovery #wr_portals { display: block }
+body #feed.portals #wr_timeline,
 body #feed.discovery #wr_timeline { display: none; }
-body #feed.discovery #wr_discovery { display: block; }
 
 body #feed #tabs { z-index: 600;position: sticky;background: #eee; padding-top:20px; top: 40px; margin-bottom:30px; border-bottom: 1px solid #ccc; height: 46px;}
 body #feed #tabs t { padding:10px 15px; display: inline-block; font-size: 12px; font-weight: bold; color:#aaa; margin-bottom:-1px;}

--- a/links/main.css
+++ b/links/main.css
@@ -55,8 +55,6 @@ body #feed .entry .thread .entry .icon { width:50px; height:50px; margin-top: -5
 body #feed .entry .message .highlight { font-weight: bold; color:#555; line-height: 25px; }
 body #feed .entry .message .inline { display: inline-block; margin: 6px 4px -6px 4px; height: 24px; }
 body #feed .entry .portal { margin-right:15px;  display:inline-block; margin-top:10px; font-weight: bold; margin-bottom:5px;}
-body #feed .entry .known_portal { display:inline-block;background: #f4f4f4;padding: 0px 5px;color: #000; }
-body #feed .entry .known_portal:hover { background:#000; color:white; }
 body #feed .entry .timestamp { color:#ccc; font-size:10pt; }
 body #feed .entry .timestamp:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .editstamp { color:#ccc; font-size:10pt; }

--- a/rotonde.js
+++ b/rotonde.js
@@ -72,13 +72,11 @@ function Rotonde(client_url)
     var n = "";
     for (var i = 0; i < m.length; i++) {
       var c = m[i];
-      switch (c) {
-        case "&": n += "&amp;"; continue;
-        case "<": n += "&lt;"; continue;
-        case ">": n += "&gt;"; continue;
-        case "\"": n += "&quot;"; continue;
-        case "'": n += "&#039;"; continue;
-      }
+      if (c === "&") { n += "&amp;"; continue; }
+      if (c === "<") { n += "&lt;"; continue; }
+      if (c === ">") { n += "&gt;"; continue; }
+      if (c === "\"") { n += "&quot;"; continue; }
+      if (c === "'") { n += "&#039;"; continue; }
       n += c;
     }
     
@@ -94,10 +92,7 @@ function Rotonde(client_url)
     for (var i = 0; i < m.length; i++) {
       var c = m[i];
       // This assumes that all attributes are wrapped in '', never "".
-      if (c == "'") {
-        n += "&#039;";
-        continue;
-      }
+      if (c === "'") { n += "&#039;"; continue; }
       n += c;
     }
     

--- a/rotonde.js
+++ b/rotonde.js
@@ -66,19 +66,42 @@ function Rotonde(client_url)
 
   this.escape_html = function(m)
   {
-    return m && m
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#039;");
+    if (!m)
+      return m;
+
+    var n = "";
+    for (var i = 0; i < m.length; i++) {
+      var c = m[i];
+      switch (c) {
+        case "&": n += "&amp;"; continue;
+        case "<": n += "&lt;"; continue;
+        case ">": n += "&gt;"; continue;
+        case "\"": n += "&quot;"; continue;
+        case "'": n += "&#039;"; continue;
+      }
+      n += c;
+    }
+    
+    return n;
   }
 
   this.escape_attr = function(m)
   {
-    // This assumes that all attributes are wrapped in '', never "".
-    return m && m
-      .replace(/'/g, "&#039;");
+    if (!m)
+      return m;
+
+    var n = "";
+    for (var i = 0; i < m.length; i++) {
+      var c = m[i];
+      // This assumes that all attributes are wrapped in '', never "".
+      if (c == "'") {
+        n += "&#039;";
+        continue;
+      }
+      n += c;
+    }
+    
+    return n;
   }
 
   // START

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -289,7 +289,7 @@ function Entry(data,host)
         continue;
       }
 
-      n += m.substring(c, space);
+      n += word;
     }
 
     m = n;
@@ -308,21 +308,34 @@ function Entry(data,host)
 
   this.link_portals = function(m)
   {
-    var words = m.split(" ");
-    var n = [];
-    for(id in words){
-      var word = words[id];
-      var name_match = r.operator.name_pattern.exec(word)
-      var portals = []; // name_match ? r.index.lookup_name(name_match[1]) : [];
-      if(portals.length > 0){
-        var remnants = word.substr(name_match[0].length);
-        n.push("<a href='"+portals[0].url+"' class='known_portal'>"+name_match[0]+"</a>"+remnants);
+    // Temporary output string.
+    // Note: += is faster than Array.join().
+    var n = "";
+    var space;
+    // c: current char index
+    for (var c = 0; c < m.length; c = space + 1) {
+      if (c > 0)
+        n += " ";
+      
+      space = m.indexOf(" ", c);
+      if (space <= -1)
+        space = m.length;
+      var word = m.substring(c, space);
+
+      if (word.length > 1 && word[0] == "@") {
+        var name_match = r.operator.name_pattern.exec(word);
+        var portals = r.operator.lookup_name(name_match[1]);
+        if (portals.length > 0) {
+          var remnants = word.substr(name_match[0].length);
+          n += "<a href='"+portals[0].url+"' class='known_portal'>"+name_match[0]+"</a>"+remnants;
+          continue;
+        }
       }
-      else{
-        n.push(word)
-      }
+
+      n += word;      
     }
-    return n.join(" ").trim();
+
+    return n;
   }
 
   this.format_style = function(m)

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -327,18 +327,21 @@ function Entry(data,host)
 
   this.format_style = function(m)
   {
-    while(m.indexOf("{*") > -1 && m.indexOf("*}") > -1){
-      m = m.replace('{*',"<b>").replace('*}',"</b>");
-    }
-    while(m.indexOf("{_") > -1 && m.indexOf("_}") > -1){
-      m = m.replace('{_',"<i>").replace('_}',"</i>");
-    }
-    while(m.indexOf("{-") > -1 && m.indexOf("-}") > -1){
-      m = m.replace('{-',"<del>").replace('-}',"</del>");
-    }
     var il;
     var ir;
-    while((il = m.indexOf("{%")) > -1 && (ir = m.indexOf("%}")) > -1){
+    // il and ir are required as we check il < ir.
+    // We don't want to replace *} {* by accident.
+    // While we're at it, use substring (faster) instead of replace (slower).
+    while ((il = m.indexOf("{*")) > -1 && (ir = m.indexOf("*}")) > -1 && il < ir) {
+      m = m.substring(0, il) + "<b>" + m.substring(il + 2, ir) + "</b>" + m.substring(ir + 2);
+    }
+    while ((il = m.indexOf("{_")) > -1 && (ir = m.indexOf("_}")) > -1 && il < ir) {
+      m = m.substring(0, il) + "<i>" + m.substring(il + 2, ir) + "</i>" + m.substring(ir + 2);
+    }
+    while ((il = m.indexOf("{-")) > -1 && (ir = m.indexOf("-}")) > -1 && il < ir) {
+      m = m.substring(0, il) + "<del>" + m.substring(il + 2, ir) + "</del>" + m.substring(ir + 2);
+    }
+    while ((il = m.indexOf("{%")) > -1 && (ir = m.indexOf("%}")) > -1 && il < ir) {
       var left = m.substring(0, il);
       var mid = m.substring(il + 2, ir);
       var right = m.substring(ir + 2);

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -234,7 +234,6 @@ function Entry(data,host)
   {
     m = r.escape_html(m);
     m = this.format_links(m);
-    m = this.highlight_portal(m);
     m = this.link_portals(m);
     m = this.format_style(m);
     return m;
@@ -301,6 +300,7 @@ function Entry(data,host)
     )
   }
 
+  // link_portals does the job better.
   this.highlight_portal = function(m)
   {
     return m.replace('@'+r.home.portal.json.name,'<t class="highlight">@'+r.escape_html(r.home.portal.json.name)+"</t>")
@@ -324,9 +324,13 @@ function Entry(data,host)
 
       if (word.length > 1 && word[0] == "@") {
         var name_match = r.operator.name_pattern.exec(word);
+        var remnants = word.substr(name_match[0].length);
+        if (name_match[1] == r.home.portal.json.name) {
+          n += "<t class='highlight'>"+name_match[0]+"</t>"+remnants;
+          continue;
+        }
         var portals = r.operator.lookup_name(name_match[1]);
         if (portals.length > 0) {
-          var remnants = word.substr(name_match[0].length);
           n += "<a href='"+portals[0].url+"' class='known_portal'>"+name_match[0]+"</a>"+remnants;
           continue;
         }

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -288,16 +288,21 @@ function Entry(data,host)
         continue;
       }
 
+      // Check for { upcoming | and }
+      if (word.length > 1 && word[0] == '{') {
+        var linkbr = m.indexOf("|", c);
+        if (linkbr < 0) { n += word; continue; }
+        var linkend = m.indexOf("}", linkbr);
+        if (linkend < 0) { n += word; continue; }
+        n += "<a href='"+m.substring(linkbr + 1, linkend)+"'>"+m.substring(c + 1, linkbr)+"</a>";
+        space = linkend;
+        continue;
+      }
+
       n += word;
     }
 
-    m = n;
-
-    // Must resist urge to optimize... -ade
-    // formats descriptive [md style](https://guides.github.com/features/mastering-markdown/#examples) links
-    return m.replace(/{(.*?)\|(.*?)}/g, 
-      function replacer(m, p1, p2) { return `<a href="${p2}">${p1}</a>`}
-    )
+    return n;
   }
 
   // link_portals does the job better.

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -3,6 +3,12 @@ function Entry(data,host)
   this.expanded = false;
   
   this.update = function(data, host) {
+    if (
+      this.timestamp == data.timestamp &&
+      this.editstamp == data.editstamp &&
+      this.id == data.id
+    ) return;
+
     this.host = host;
   
     this.message = data.message;
@@ -378,19 +384,18 @@ function Entry(data,host)
 
   this.detect_mention = function()
   {
-    var im = false;
     if(this.target){
       // Mention tag, eg '@dc'
       const mentionTag = '@' + r.home.portal.json.name
       const msg = this.message.toLowerCase()
       // We want to match messages containing @dc, but NOT ones containing eg. @dcorbin
       if(msg.endsWith(mentionTag) || msg.indexOf(mentionTag + ' ') > -1) {
-        im = true;
+        return true;
       }
-      im = im || has_hash(r.home.portal.hashes(), this.target);
+      return has_hash(r.home.portal.hashes(), this.target);
     }
 
-    return im;
+    return false;
   }
 
   this.thread_length = function()

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -32,9 +32,9 @@ function Entry(data,host)
   this.element = null;
   this.element_html = null;
 
-  this.to_element = function(timeline, c, cmin, cmax)
+  this.to_element = function(timeline, c, cmin, cmax, offset)
   {
-    if (c < cmin || cmax <= c) {
+    if (c < 0 || c < cmin || cmax <= c) {
       // Out of bounds - remove if existing, don't add.
       this.remove_element();
       return null;
@@ -49,9 +49,12 @@ function Entry(data,host)
       }
       this.element.innerHTML = html;
       this.element_html = html;
+      timeline.appendChild(this.element);
     }
-    // Always append as last.
-    timeline.appendChild(this.element);
+
+    // The entry is being added to an ordered collection.
+    move_element(this.element, c - cmin + offset);
+
     return this.element;
   }
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -420,14 +420,15 @@ function Entry(data,host)
 
   this.detect_mention = function()
   {
-    if(this.target){
-      // Mention tag, eg '@dc'
-      const mentionTag = '@' + r.home.portal.json.name
-      const msg = this.message.toLowerCase()
-      // We want to match messages containing @dc, but NOT ones containing eg. @dcorbin
-      if(msg.endsWith(mentionTag) || msg.indexOf(mentionTag + ' ') > -1) {
-        return true;
-      }
+    // Mention tag, eg '@dc'
+    const mentionTag = '@' + r.home.portal.json.name
+    const msg = this.message.toLowerCase()
+    // We want to match messages containing @dc, but NOT ones containing eg. @dcorbin
+    if(msg.endsWith(mentionTag) || msg.indexOf(mentionTag + ' ') > -1) {
+      return true;
+    }
+
+    if(this.target && this.target.length > 0){
       return has_hash(r.home.portal, this.target);
     }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -69,11 +69,7 @@ function Feed(feed_urls)
 
   this.start = function()
   {
-    this.queue.push(r.home.portal.url);
-    for(id in r.home.portal.json.port){
-      var url = r.home.portal.json.port[id];
-      this.queue.push(url)
-    }
+    this.queue = [r.home.portal.url].concat(r.home.portal.json.port);
     this.connect();
   }
 
@@ -155,7 +151,7 @@ function Feed(feed_urls)
       var port_url = r.home.portal.json.port[id];
       if (port_url != portal.url) continue;
       port_url = portal.archive.url || portal.url;
-      if (!port_url.replace("dat://", "").indexOf("/") > -1)
+      if (!port_url.endsWith("/"))
         port_url = port_url + "/";
       r.home.portal.json.port[id] = port_url;
       break;
@@ -311,7 +307,7 @@ function Feed(feed_urls)
     }
 
     var now = new Date();
-    var entries_now = [];
+    var entries_now = new Set();
     for (id in sorted_entries){
       var entry = sorted_entries[id];
 
@@ -330,7 +326,7 @@ function Feed(feed_urls)
         c = -2;
       var elem = !entry ? null : entry.to_element(timeline, c, cmin, cmax, coffset);
       if (elem != null) {
-        entries_now.push(entry);
+        entries_now.add(entry);
       }
       if (c >= 0)
         ca++;
@@ -339,7 +335,7 @@ function Feed(feed_urls)
     // Remove any "zombie" entries - removed entries not belonging to any portal.
     for (id in this.entries_prev) {
       var entry = this.entries_prev[id];
-      if (entries_now.indexOf(entry) > -1)
+      if (entries_now.has(entry))
         continue;
       entry.remove_element();
     }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -134,7 +134,14 @@ function Feed(feed_urls)
 
     r.home.feed.queue = r.home.feed.queue.slice(1);
 
-    var portal = new Portal(url);
+    var portal;
+    try {
+      portal = new Portal(url);
+    } catch (err) {
+      // Malformed URL or failed connecting? Skip!
+      r.home.feed.next();
+      return;
+    }
     portal.connect()
     r.home.feed.update_log();
   }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -215,8 +215,8 @@ function Feed(feed_urls)
       entries = entries.concat(portal.entries());
     }
 
-    this.mentions = entries.filter(function (e) { return e.is_visible("", "mentions") }).length
-    this.whispers = entries.filter(function (e) { return e.is_visible("", "whispers") }).length
+    this.mentions = 0;
+    this.whispers = 0;
 
     var sorted_entries = entries.sort(function (a, b) {
       return b.timestamp - a.timestamp;
@@ -253,6 +253,15 @@ function Feed(feed_urls)
     var entries_now = [];
     for (id in sorted_entries){
       var entry = sorted_entries[id];
+
+      // We iterate through entries anyway - let's just fill this.mentions & this.whispers here.
+      // This is faster than filtering twice + iterating through the entries manually,
+      // as the iteration overhead is shared and we don't depend on the filter result.
+      if (entry.is_visible("", "mentions"))
+        this.mentions++;
+      else if (entry.is_visible("", "whispers"))
+        this.whispers++;
+
       var c = ca;
       if (!entry || entry.timestamp > now)
         c = -1;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -269,7 +269,7 @@ function Feed(feed_urls)
 
     for(var id in r.home.feed.portals){
       var portal = r.home.feed.portals[id];
-      entries = entries.concat(portal.entries());
+      entries.push.apply(entries, portal.entries());
     }
 
     this.mentions = 0;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -375,9 +375,9 @@ function has_hash(hashes_a, hashes_b)
   if (typeof(hashes_b) === "string") {
     var hash_b = to_hash(hashes_b);
 
-    if (typeof(hashes_a.has) === "function")
-       // Assuming that hashes_a is already filled with pure hashes...
-      return hashes_a.has(hash_b);
+    if (set_a)
+       // Assuming that set_a is already filled with pure hashes...
+      return set_a.has(hash_b);
 
     for (var a in hashes_a) {
       var hash_a = to_hash(hashes_a[a]);
@@ -396,19 +396,21 @@ function has_hash(hashes_a, hashes_b)
       if (!hash_b)
         continue;
 
+      // Assuming that set_a is already filled with pure hashes...
       if (set_a.has(hash_b))
         return true;
     }
     return false;
   }
 
-  if (set_a) {
+  if (set_b) {
     // Fast path: iterator x set
     for (var a in hashes_a) {
       var hash_a = to_hash(hashes_a[a]);
       if (!hash_a)
         continue;
 
+      // Assuming that set_b is already filled with pure hashes...
       if (set_b.has(hash_a))
         return true;
     }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -363,16 +363,16 @@ function has_hash(hashes_a, hashes_b)
   var set_a = hashes_a instanceof Set ? hashes_a : null;
   if (hashes_a) {
     if (typeof(hashes_a.hashes_set) === "function")
-      hashes_a = set_a = hashes_a.hashes_set();
-    else if (typeof(hashes_a.hashes) === "function")
+      set_a = hashes_a.hashes_set();
+    if (typeof(hashes_a.hashes) === "function")
       hashes_a = hashes_a.hashes();
   }
 
   var set_b = hashes_b instanceof Set ? hashes_b : null;
   if (hashes_b) {
     if (typeof(hashes_b.hashes_set) === "function")
-      hashes_b = set_b = hashes_b.hashes_set();
-    else if (typeof(hashes_b.hashes) === "function")
+      set_b = hashes_b.hashes_set();
+    if (typeof(hashes_b.hashes) === "function")
       hashes_b = hashes_b.hashes();
   }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -33,12 +33,10 @@ function Feed(feed_urls)
 
   this.wr_timeline_el = document.createElement('div'); this.wr_timeline_el.id = "wr_timeline";
   this.wr_portals_el = document.createElement('div'); this.wr_portals_el.id = "wr_portals";
-  this.wr_discovery_el = document.createElement('div'); this.wr_discovery_el.id = "wr_discovery";
 
   this.el.appendChild(this.wr_el);
   this.wr_el.appendChild(this.wr_timeline_el);
   this.wr_el.appendChild(this.wr_portals_el);
-  this.wr_el.appendChild(this.wr_discovery_el);
   
   this.queue = [];
   this.portals = [];
@@ -76,7 +74,12 @@ function Feed(feed_urls)
 
   this.next = async function()
   {
-    if(r.home.feed.queue.length < 1){ console.log("Reached end of queue"); r.home.feed.update_log(); return; }
+    if(r.home.feed.queue.length < 1){
+      console.log("Reached end of queue");
+      r.home.update();
+      r.home.feed.update_log();
+      return;
+    }
 
     var url = r.home.feed.queue[0];
 
@@ -195,6 +198,7 @@ function Feed(feed_urls)
     var ca = 0;
     var cmin = this.page * this.page_size;
     var cmax = cmin + this.page_size;
+    var coffset = 0;
 
     if (this.page > 0) {
       // Create page_prev_el if missing.
@@ -205,7 +209,10 @@ function Feed(feed_urls)
         this.page_prev_el.setAttribute('data-validate', 'true');
         this.page_prev_el.innerHTML = "<t class='message' dir='auto'>↑</t>";
         timeline.appendChild(this.page_prev_el);
+        move_element(this.portals_refresh_el, 0);
       }
+      // Add 1 to the child offset.
+      coffset++;
     } else {
       // Remove page_prev_el.
       if (this.page_prev_el) {
@@ -223,7 +230,7 @@ function Feed(feed_urls)
         c = -1;
       else if (!entry.is_visible(r.home.feed.filter, r.home.feed.target))
         c = -2;
-      var elem = !entry ? null : entry.to_element(timeline, c, cmin, cmax);
+      var elem = !entry ? null : entry.to_element(timeline, c, cmin, cmax, coffset);
       if (elem != null) {
         entries_now.push(entry);
       }

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -43,7 +43,7 @@ function Feed(feed_urls)
 
   this.urls = {};
   this.filter = "";
-  this.target = window.location.hash ? window.location.hash.replace("#","") : "";
+  this.target = window.location.hash ? window.location.hash.substring(1) : "";
   this.timer = null;
   this.mentions = 0;
 
@@ -186,7 +186,7 @@ function Feed(feed_urls)
   this.refresh = function(why)
   {
     if (why && why.startsWith("delay: ")) {
-      why = why.replace("delay: ", "");
+      why = why.substring(7 /* "delay: ".length */);
       // Delay the refresh to occur again after all portals refreshed.
       setTimeout(async function() {
         for (var id in r.home.feed.portals) {

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -133,6 +133,10 @@ function Feed(feed_urls)
   this.get_portal = function(hash) {
     hash = to_hash(hash);
 
+    // I wish JS had weak references...
+    // WeakMap stores weak keys, which isn't what we want here.
+    // WeakSet isn't enumerable, which means we can't get its value(s).
+
     var portal = this.__get_portal_cache__[hash];
     if (portal)
       return portal;
@@ -141,7 +145,8 @@ function Feed(feed_urls)
       return this.__get_portal_cache__[hash] = r.home.portal;
 
     for (var id in r.home.feed.portals) {
-      if (has_hash(portal = r.home.feed.portals[id], hash))
+      portal = r.home.feed.portals[id];
+      if (has_hash(portal, hash))
         return this.__get_portal_cache__[hash] = portal;
     }
     
@@ -440,7 +445,9 @@ function portal_from_hash(url)
 {
   var hash = to_hash(url);
 
-  r.home.feed.get_portal(url);
+  var portal = r.home.feed.get_portal(hash);
+  if (portal)
+    return "@" + portal.json.name;
   
   return hash.substr(0,12)+".."+hash.substr(hash.length-3,2);
 }

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -205,13 +205,15 @@ function Home()
   this.collect_network = function()
   {
     var collection = [];
+    var added = new Set();
 
     for(id in r.home.feed.portals){
       var portal = r.home.feed.portals[id];
       for(i in portal.json.port){
         var p = portal.json.port[i];
-        if(collection.indexOf(p) > -1){ continue; }
-        collection.push(p)
+        if(added.has(p)){ continue; }
+        collection.push(p);
+        added.add(p);
       }
     }
     return collection;

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -307,7 +307,14 @@ function Home()
       return;
     }
 
-    var portal = new Portal(url);
+    var portal;
+    try {
+      portal = new Portal(url);
+    } catch (err) {
+      // Malformed URL or failed connecting? Skip!
+      r.home.discover_next_step();
+      return;
+    }
     portal.discover();
   }
 }

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -28,7 +28,7 @@ function Home()
   this.discovery_enabled = false;
   this.discovered = [];
   this.discovered_count = 0;
-  this.discovered_hashes = [];
+  this.discovered_hashes = new Set();
   this.discovering = -1;
 
   this.portals_page = 0;
@@ -282,7 +282,7 @@ function Home()
       return;
     }
 
-    r.home.discovered_hashes = r.home.discovered_hashes.concat(portal.hashes());
+    portal.hashes().forEach(r.home.discovered_hashes.add, r.home.discovered_hashes);
 
     if (portal.is_known(true)) {
       r.home.discover_next_step();

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -29,9 +29,12 @@ function Home()
   this.discovered = [];
   this.discovered_count = 0;
   this.discovered_hashes = [];
-  this.discovery_page = 0;
-  this.discovery_page_size = 16;
   this.discovering = -1;
+
+  this.portals_page = 0;
+  this.portals_page_size = 16;
+  this.page_target = null;
+  this.page_filter = null;
 
   this.display_log = true;
 
@@ -48,62 +51,92 @@ function Home()
 
   this.update = function()
   {
-    document.title = "@"+r.home.portal.json.name;
-    this.network = r.home.collect_network();
+    document.title = "@"+this.portal.json.name;
+    this.network = this.collect_network();
 
-    // Portal List
-    for (id in this.feed.portals) {
-      var portal = this.feed.portals[id];
-      portal.badge_add(null, r.home.feed.wr_portals_el);
+    this.portals_page = this.feed.page;
+    if (this.portals_page_target != this.feed.target ||
+        this.portals_page_filter != this.feed.filter) {
+      // Jumping between tabs? Switching filters? Reset!
+      this.portals_page = 0;
     }
+    this.portals_page_target = this.feed.target;
+    this.portals_page_filter = this.feed.filter;
 
-    // Discovery List
-    var sorted_discovered = r.home.discovered.sort(function(a, b) {
-      return a.updated() < b.updated() ? 1 : -1;
-    });
-
-    var discovery = r.home.feed.wr_discovery_el;
-
-    this.discovery_page = r.home.feed.page;
-    var cmin = this.discovery_page * (this.discovery_page_size - 2);
-    var cmax = cmin + this.discovery_page_size - 2;
+    var cmin = this.portals_page * (this.portals_page_size - 2);
+    var cmax = cmin + this.portals_page_size - 2;
     this.discovered_count = 0;
 
-    if (this.discovery_page > 0) {
+    var portals = this.feed.wr_portals_el;
+
+    if (this.portals_page > 0) {
       // Create page_prev_el if missing.
-      if (!this.discovery_page_prev_el) {
-        this.discovery_page_prev_el = document.createElement('div');
-        this.discovery_page_prev_el.className = 'badge paginator page-prev';
-        this.discovery_page_prev_el.setAttribute('data-operation', 'page:--');
-        this.discovery_page_prev_el.setAttribute('data-validate', 'true');
-        this.discovery_page_prev_el.innerHTML = "<a class='message' dir='auto'>&lt</a>";
-        discovery.appendChild(this.discovery_page_prev_el);
+      if (!this.portals_page_prev_el) {
+        this.portals_page_prev_el = document.createElement('div');
+        this.portals_page_prev_el.className = 'badge paginator page-prev';
+        this.portals_page_prev_el.setAttribute('data-operation', 'page:--');
+        this.portals_page_prev_el.setAttribute('data-validate', 'true');
+        this.portals_page_prev_el.innerHTML = "<a class='message' dir='auto'>&lt</a>";
+        portals.appendChild(this.portals_page_prev_el);
+        move_element(this.portals_page_prev_el, 0);
       }
       // Remove refresh_el.
-      if (this.discovery_refresh_el) {
-        discovery.removeChild(this.discovery_refresh_el);
-        this.discovery_refresh_el = null;
+      if (this.portals_refresh_el) {
+        portals.removeChild(this.portals_refresh_el);
+        this.portals_refresh_el = null;
       }
     } else {
       // Create refresh_el if missing.
-      if (!this.discovery_refresh_el) {
-        this.discovery_refresh_el = document.createElement('div');
-        this.discovery_refresh_el.setAttribute('data-operation', 'discovery_refresh');
-        this.discovery_refresh_el.setAttribute('data-validate', 'true');
-        this.discovery_refresh_el.innerHTML = "<a class='message' dir='auto'>↻</a>";
-        discovery.appendChild(this.discovery_refresh_el);
+      if (!this.portals_refresh_el) {
+        this.portals_refresh_el = document.createElement('div');
+        this.portals_refresh_el.setAttribute('data-validate', 'true');
+        this.portals_refresh_el.innerHTML = "<a class='message' dir='auto'>↻</a>";
+        portals.appendChild(this.portals_refresh_el);
+        move_element(this.portals_refresh_el, 0);
       }
-      // Update classes.
-      this.discovery_refresh_el.className = "badge paginator refresh";
-      if (this.discovering > -1) {
-        this.discovery_refresh_el.className += " refreshing";
+      // Update classes and operation.
+      this.portals_refresh_el.className = "badge paginator refresh";
+      if (this.feed.target == "discovery") {
+        this.portals_refresh_el.setAttribute('data-operation', 'discovery_refresh');
+        if (this.discovering > -1) {
+          this.portals_refresh_el.className += " refreshing";
+        }
+      } else {
+        this.portals_refresh_el.setAttribute('data-operation', 'portals_refresh');
+        if (this.feed.queue.length > 0) {
+          this.portals_refresh_el.className += " refreshing";
+        }
       }
       // Remove page_prev_el.
-      if (this.discovery_page_prev_el) {
-        discovery.removeChild(this.discovery_page_prev_el);
-        this.discovery_page_prev_el = null;
+      if (this.portals_page_prev_el) {
+        portals.removeChild(this.portals_page_prev_el);
+        this.portals_page_prev_el = null;
       }
     }
+
+    // Portal List
+    if (this.feed.target == "portals") {
+      // We're rendering the portals tab - sort them and display them.
+      var sorted_portals = this.feed.portals.sort(function(a, b) {
+        return a.updated(false) < b.updated(false) ? 1 : -1;
+      });
+      for (id in sorted_portals) {
+        var portal = sorted_portals[id];
+        // Offset always === 1. The 0th element is always a pagination element.
+        portal.badge_add('', portals, id, cmin, cmax, 1);
+      }
+    } else {
+      // We're rendering another tab - hide all portals.
+      for (id in this.feed.portals) {
+        var portal = this.feed.portals[id];
+        portal.badge_add('', portals, -1);
+      }
+    }
+
+    // Discovery List
+    var sorted_discovered = this.discovered.sort(function(a, b) {
+      return a.updated(false) < b.updated(false) ? 1 : -1;
+    });
 
     for (var id in sorted_discovered) {
       var portal = sorted_discovered[id];
@@ -119,27 +152,36 @@ function Home()
 
       // TODO: Allow custom discovery time filter.
       // if (portal.time_offset() / 86400 > 3)
-          // c = -2;
+          // c = -1;
+      
+      if (this.feed.target != "discovery")
+        c = -1;
 
-      portal.badge_add('discovery', discovery, c, cmin, cmax);
+      // Offset always === 1. The 0th element is always a pagination element.
+      portal.badge_add('discovery', portals, c, cmin, cmax, 1);
     }
 
-    if (this.discovered_count >= cmax) {
+    var count = this.feed.portals.length;
+    if (this.feed.target == "discovery") {
+      count = this.discovered_count;
+    }
+
+    if (count >= cmax) {
       // Create page_next_el if missing.
-      if (!this.discovery_page_next_el) {
-        this.discovery_page_next_el = document.createElement('div');
-        this.discovery_page_next_el.className = 'badge paginator page-next';
-        this.discovery_page_next_el.setAttribute('data-operation', 'page:++');
-        this.discovery_page_next_el.setAttribute('data-validate', 'true');
-        this.discovery_page_next_el.innerHTML = "<a class='message' dir='auto'>&gt</a>";
+      if (!this.portals_page_next_el) {
+        this.portals_page_next_el = document.createElement('div');
+        this.portals_page_next_el.className = 'badge paginator page-next';
+        this.portals_page_next_el.setAttribute('data-operation', 'page:++');
+        this.portals_page_next_el.setAttribute('data-validate', 'true');
+        this.portals_page_next_el.innerHTML = "<a class='message' dir='auto'>&gt</a>";
       }
       // Always append as last.
-      discovery.appendChild(this.discovery_page_next_el);
+      portals.appendChild(this.portals_page_next_el);
     } else {
       // Remove page_next_el.
-      if (this.discovery_page_next_el) {
-        discovery.removeChild(this.discovery_page_next_el);
-        this.discovery_page_next_el = null;
+      if (this.portals_page_next_el) {
+        portals.removeChild(this.portals_page_next_el);
+        this.portals_page_next_el = null;
       }
     }
 
@@ -243,7 +285,7 @@ function Home()
     r.home.discovered.push(portal);
     r.home.update();
     r.home.feed.refresh("discovery");
-    setTimeout(r.home.discover_next_step, 250);
+    setTimeout(r.home.discover_next_step, 50);
   }
   this.discover_next_step = function()
   {

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -78,7 +78,6 @@ function Home()
         this.portals_page_prev_el.setAttribute('data-validate', 'true');
         this.portals_page_prev_el.innerHTML = "<a class='message' dir='auto'>&lt</a>";
         portals.appendChild(this.portals_page_prev_el);
-        move_element(this.portals_page_prev_el, 0);
       }
       // Remove refresh_el.
       if (this.portals_refresh_el) {
@@ -118,7 +117,7 @@ function Home()
     if (this.feed.target == "portals") {
       // We're rendering the portals tab - sort them and display them.
       var sorted_portals = this.feed.portals.sort(function(a, b) {
-        return a.updated(false) < b.updated(false) ? 1 : -1;
+        return b.updated(false) - a.updated(false);
       });
       for (id in sorted_portals) {
         var portal = sorted_portals[id];
@@ -135,7 +134,7 @@ function Home()
 
     // Discovery List
     var sorted_discovered = this.discovered.sort(function(a, b) {
-      return a.updated(false) < b.updated(false) ? 1 : -1;
+      return b.updated(false) - a.updated(false);
     });
 
     for (var id in sorted_discovered) {
@@ -174,9 +173,8 @@ function Home()
         this.portals_page_next_el.setAttribute('data-operation', 'page:++');
         this.portals_page_next_el.setAttribute('data-validate', 'true');
         this.portals_page_next_el.innerHTML = "<a class='message' dir='auto'>&gt</a>";
+        portals.appendChild(this.portals_page_next_el);
       }
-      // Always append as last.
-      portals.appendChild(this.portals_page_next_el);
     } else {
       // Remove page_next_el.
       if (this.portals_page_next_el) {
@@ -184,6 +182,10 @@ function Home()
         this.portals_page_next_el = null;
       }
     }
+
+    // Reposition paginators.
+    move_element(this.portals_page_prev_el, 0);
+    move_element(this.portals_page_next_el, portals.childElementCount - 1);
 
   }
 
@@ -202,9 +204,12 @@ function Home()
     }
   }
 
-  this.collect_network = function()
+  this.__network_cache__ = null;
+  this.collect_network = function(invalidate = false)
   {
-    var collection = [];
+    if (this.__network_cache__ && !invalidate)
+      return this.__network_cache__;
+    var collection = this.__network_cache__ = [];
     var added = new Set();
 
     for(id in r.home.feed.portals){

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -367,7 +367,8 @@ function Operator(el)
       return;
     }
 
-    if(portals[0].expanded.indexOf(ref) < 0){ portals[0].expanded.push(ref+""); }
+    var entry = portals[0].entries()[ref];
+    if (entry) entry.expanded = true;
   }
 
   this.commands.collapse = function(p, option)
@@ -381,8 +382,8 @@ function Operator(el)
       return;
     }
 
-    var index = portals[0].expanded.indexOf(ref+"");
-    if(index > -1){ portals[0].expanded.splice(index, 1); }
+    var entry = portals[0].entries()[ref];
+    if (entry) entry.expanded = false;
   }
 
   this.commands.night_mode = function(p, option)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -291,7 +291,7 @@ function Operator(el)
       throw new Error('No valid parameter given for page command!');
     if (page < 0)
       page = 0;
-    r.home.feed.page_jump(page);
+    r.home.feed.page_jump(page, false); // refresh = false, as we refresh again on command validation
   }
 
   this.commands.help = function(p, option) {

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -195,7 +195,7 @@ function Operator(el)
     }
     r.home.portal.json.port.push("dat://"+option+"/");
     r.home.feed.queue.push("dat://"+option+"/");
-    r.home.feed.next();
+    r.home.feed.connect();
     r.home.save();
   }
 
@@ -349,7 +349,7 @@ function Operator(el)
       }
     }
     if (r.home.feed.queue.length > 0)
-      r.home.feed.next();
+      r.home.feed.connect();
   }
 
   this.commands.discovery_refresh = function(p, option) {

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -87,6 +87,7 @@ function Operator(el)
     this.commands[command](params,option);
 
     this.input_el.value = "";
+    r.home.update();
     r.home.feed.refresh(command+" validated");
   }
 
@@ -328,6 +329,26 @@ function Operator(el)
               throw new Error('Invalid parameter given for help command!');
           }
       }
+  }
+
+  this.commands.portals_refresh = function(p, option) {
+    for (var id in r.home.portal.json.port) {
+      var url = r.home.portal.json.port[id];
+      var loaded = false;
+      for (var id_loaded in r.home.feed.portals) {
+        var portal = r.home.feed.portals[id_loaded];
+        if (!has_hash(portal, url))
+          continue;
+        loaded = true;
+        portal.refresh();
+        break;
+      }
+      if (!loaded) {
+        r.home.feed.queue.push(url);
+      }
+    }
+    if (r.home.feed.queue.length > 0)
+      r.home.feed.next();
   }
 
   this.commands.discovery_refresh = function(p, option) {

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -169,13 +169,14 @@ function Operator(el)
       console.log("could not find",path)
     }
 
-    for(id in r.home.feed.portals){
-      if (!has_hash(r.home.feed.portals[id], path))
-        continue;
-      var portal = r.home.feed.portals.splice(id, 1)[0];
+    var portal = r.home.feed.get_portal(path);
+    if (portal) {
+      r.home.feed.portals.splice(portal.id, 1)[0];
+      for (var id in r.home.feed.portals) {
+        r.home.feed.portals[id].id = id;
+      }
       portal.badge_remove();
       portal.entries_remove();
-      break;
     }
 
     r.home.save();

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -53,6 +53,7 @@ function Portal(url)
 
     try {
       p.json = JSON.parse(p.file);
+      p.file = null;
       r.home.feed.register(p);
     } catch (err) {
       console.log('parsing failed: ', p.url);
@@ -75,6 +76,7 @@ function Portal(url)
     
     try {
       p.json = JSON.parse(p.file);
+      p.file = null;
     } catch (err) {
       console.log('parsing failed: ', p.url);
       r.home.discover_next();
@@ -100,7 +102,12 @@ function Portal(url)
       }
     }
 
-    p.json = JSON.parse(p.file);
+    try {
+      p.json = JSON.parse(p.file);
+      p.file = null;
+    } catch (err) {
+      console.log('parsing failed: ', p.url);
+    }
     p.__entries_cache__ = null;
   }
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -144,7 +144,7 @@ function Portal(url)
     }
   }
 
-  this.relationship = function(target = r.home.portal.hashes())
+  this.relationship = function(target = r.home.portal.hashes_set())
   {
     if (has_hash(this, target)) return create_rune("portal", "self");
     if (has_hash(this.json.port, target)) return create_rune("portal", "both");
@@ -285,7 +285,7 @@ function Portal(url)
 
   this.is_known = function(discovered)
   {
-    var hashes = this.hashes();
+    var hashes = this.hashes_set();
     var portals = [].concat(r.home.feed.portals);
     if (discovered)
       portals = portals.concat(r.home.discovered);

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -303,10 +303,11 @@ function move_element(el, index) {
     // offset < 0: Element needs to be pushed "left" / "up".
     // -offset is the "# of elements we expected there not to be",
     // thus how many places we need to shift to the left.
+    var swap;
     tmp = el;
-    while ((tmp = tmp.previousElementSibling) && offset < 0)
+    while ((swap = tmp) && (tmp = tmp.previousElementSibling) && offset < 0)
       offset++;
-    tmp.after(el);
+    swap.before(el);
     
   } else {
     // offset > 0: Element needs to be pushed "right" / "down".

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -286,14 +286,19 @@ function Portal(url)
   this.is_known = function(discovered)
   {
     var hashes = this.hashes_set();
-    var portals = [].concat(r.home.feed.portals);
-    if (discovered)
-      portals = portals.concat(r.home.discovered);
 
-    for (id in portals) {
-      var lookup = portals[id];
+    for (var id in r.home.feed.portals) {
+      var lookup = r.home.feed.portals[id];
       if (has_hash(hashes, lookup))
         return true;
+    }
+
+    if (discovered) {
+      for (var id in r.home.discovered) {
+        var lookup = r.home.discovered[id];
+        if (has_hash(hashes, lookup))
+          return true;
+      }
     }
 
     return false;

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -121,19 +121,20 @@ function Portal(url)
       return this.__entries_cache__;
     var e = this.__entries_cache__ = [];
 
+    var entry;
     for (var id in this.json.feed) {
       var raw = this.json.feed[id];
-      var entry = this.__entries_map__[raw.timestamp];
+      entry = this.__entries_map__[raw.timestamp];
       if (entry == null)
         this.__entries_map__[raw.timestamp] = entry = new Entry(this.json.feed[id], p);
       else
         entry.update(this.json.feed[id], p);
       entry.id = id;
       entry.is_mention = entry.detect_mention();
-      e.push(entry);
+      e[id] = entry;
     }
 
-    this.last_entry = e[p.json.feed.length - 1];
+    this.last_entry = entry;
     return e;
   }
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -59,7 +59,7 @@ function Portal(url)
       console.log('parsing failed: ', p.url);
     }
 
-    setTimeout(r.home.feed.next, 750);
+    setTimeout(r.home.feed.next, r.home.feed.connection_delay);
   }
 
   this.discover = async function()

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -339,10 +339,11 @@ function move_element(el, index) {
     // offset > 0: Element needs to be pushed "right" / "down".
     // offset is the "# of elements we expected before us but weren't there",
     // thus how many places we need to shift to the right.
+    var swap;
     tmp = el;
-    while ((tmp = tmp.nextElementSibling) && offset > 0)
+    while ((swap = tmp) && (tmp = tmp.nextElementSibling) && offset > 0)
       offset--;
-    tmp.after(el);
+    swap.after(el);
   }
 
 }

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -17,8 +17,6 @@ function Portal(url)
   this.badge_element = null;
   this.badge_element_html = null;
 
-  this.expanded = [];
-
   this.start = async function()
   {
     var file = await this.archive.readFile('/portal.json',{timeout: 2000}).then(console.log("done!"));
@@ -125,7 +123,6 @@ function Portal(url)
         entry.update(this.json.feed[id], p);
       entry.id = id;
       entry.is_mention = entry.detect_mention();
-      entry.expanded = this.expanded.indexOf(id+"") > -1;
       e.push(entry);
     }
 


### PR DESCRIPTION
- Implement `move_element` to move elements, thus manipulating the DOM much less aggressively.
This is what `Entry.to_element` / `Portal.add_badge` built towards. Before, all elements were blindly re-added, causing all elements to get invalidated with every "refresh."
- Merge portals list and discovery into the same wrapper.
- Replace (most of) `format_links` with character index based manipulation instead of split & join. Still made it simple to use.
- Give `sort` direct delta (faster sorting in my testing).
- "Cache" (reuse) values _a lot._ No, that's not "caching to disk," but just storing and reusing function results that would otherwise take (relatively) long to get to.
- Optimize `to_hash`.
- Add `Portal.hashes_set()`, allow `has_hash` to compare against `Set`.
- Use `Set.has` instead of `Array.indexOf`
- Fix timestamps -> local time (offset wasn't required, Date already takes care of everything).
- Add pagination to portals tab.
- Add "refresh" button to portals tab - refreshes feed and attempts to reconnect to "failed" portals.
- Some smaller stuff. I really lost track 😅

My portal (following 114 portals, 1998 entries at the moment) doesn't stutter while loading anymore.  