### PR TITLE
Implement "big picture"

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -102,8 +102,6 @@ body #feed.mentions #tab_mentions,
 body #feed.whispers #tab_whispers,
 body #feed.portals #tab_discovery {}
 
-.hidden { display: none; }
-
 body #operator { position: fixed; top: 0px;overflow: hidden;z-index: 500;font-family: "input_mono_regular";margin: 0px auto;min-width: 400px;width: 100vw;top: 0px;background: #fff;z-index: 999;padding: 5px 0px;box-shadow: 0px 0px 2px rgba(0,0,0,0.15);min-height: 50px; }
 body #operator textarea { display: flex; color: white; width: 100%; align-content: center; height: 20px; resize: none; max-height: 100px; background: transparent; align-self: center; transition: all 150ms; line-height: 22px; min-height:20px; color:#000;padding-left: 15px;}
 body #operator textarea.drag { background: #b7b7b7; }
@@ -152,3 +150,33 @@ html.night { filter: hue-rotate(180deg) invert(); background: #111; }
 html.night body #feed .entry img.media { filter: hue-rotate(180deg) invert(); background: #666; }
 html.night body #feed .entry video.media { filter: hue-rotate(180deg) invert(); }
 html.night ::-webkit-media-controls-panel { background: #000; }
+
+body #feed #tabs,
+body #feed #wr_timeline,
+body #feed #wr_portals { transition: filter 0.15s; will-change: filter;}
+body.in-bigpicture #feed #tabs,
+body.in-bigpicture #feed #wr_timeline,
+body.in-bigpicture #feed #wr_portals { filter: blur(2px) saturate(50%); }
+
+body #feed .bigpicture { background: rgba(31, 31, 31, 0.9); position: absolute; display: block; z-index: 900; top: 0; right: 0; left: 0; min-height: calc(100vh - 60px); }
+body #feed .bigpicture > .entry { margin: calc(100vh - 60px) auto 0 auto; width: 100%; max-width: 700px; }
+/* In case questions arise:
+ * Top is: Center of view = (.entry.top) - 50vh + entry peeking height
+ * The maximum height is: view height - operator height - entry peeking height - padding
+ * This is horrible.
+ * -ade
+ */
+body #feed .bigpicture > .entry .media { position: absolute; top: calc(-50vh + 60px); left: 50%; margin: 0; transform: translate(-50%, -50%); max-width: calc(100vw - 30px); max-height: calc(100vh - 60px - 60px - 30px); }
+
+body .fade-in { animation: fade-in 0.15s forwards; }
+@keyframes fade-in {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+body .fade-out-die { animation: fade-out-die 0.15s forwards; pointer-events: none; }
+@keyframes fade-out-die {
+  0% { opacity: 1; }
+  100% { opacity: 0; display: none !important; }
+}
+
+body .hidden { display: none !important; pointer-events: none; }

--- a/rotonde.js
+++ b/rotonde.js
@@ -123,6 +123,7 @@ function Rotonde(client_url)
 
   this.mouse_down = function(e)
   {
+    if (e.button != 0) { return; } // We only care about the main mouse button.
     if(!e.target.getAttribute("data-operation")){ return; }
     e.preventDefault();
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -201,12 +201,27 @@ function Entry(data,host)
       var origin = this.thread_root().host.url;
       origin += origin.toString().slice(-1) == "/" ? "" : "/";
 
-      if(audiotypes.indexOf(extension) > -1){ html += "<audio class='media' src='"+origin+"media/content/"+media+"' controls />"; }
-      else if(videotypes.indexOf(extension) > -1){ html += "<video class='media' src='"+origin+"media/content/"+media+"' controls />"; }
-      else if(imagetypes.indexOf(extension) > -1){ html += "<img class='media' src='"+origin+"media/content/"+media+"'/>"; }
-      else{ html +="<a class='media' href='"+origin+"media/content/"+media+"'>&gt;&gt; "+media+"</a>"; }
+      if(audiotypes.indexOf(extension) > -1){ html += this.rmc_element(origin, media, "audio", "media", "controls", ""); }
+      else if(videotypes.indexOf(extension) > -1){ html += this.rmc_element(origin, media, "video", "media", "controls", ""); }
+      else if(imagetypes.indexOf(extension) > -1){ html += this.rmc_bigpicture(origin, media, "img", "media", "", ""); }
+      else{ html += this.rmc_element(origin, media, "a", "media", "", "&gt;&gt; "+media); }
     }
     return html;
+  }
+  this.rmc_element = function(origin, media, tag, classes = "media", extra = "", inner = "")
+  {
+    return "<"+tag+" class='"+classes+"' "+(tag==="a"?"href":"src")+"='"+origin+"media/content/"+media+"' "+extra+">"+inner+"</"+tag+">";
+  }
+  this.rmc_bigpicture = function(origin, media, tag, classes = "media", extra = "", inner = "")
+  {
+    return this.rmc_element(origin, media, "a", "thin-wrapper", "onclick='return false'",
+      this.rmc_element(origin, media, tag, classes, extra + " data-operation='big:"+this.host.json.name+"-"+this.id+"' data-validate='true'", inner)
+    );
+  }
+
+  this.big = function()
+  {
+    r.home.feed.bigpicture_toggle(() => this.to_html());
   }
 
   this.rune = function()

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -386,6 +386,26 @@ function Operator(el)
     if (entry) entry.expanded = false;
   }
 
+  this.commands.big = function(p, option)
+  {
+    if (!p && !option) {
+      r.home.feed.bigpicture_hide();
+      return;
+    }
+
+    var name = option.split("-")[0];
+    var ref = parseInt(option.split("-")[1]);
+
+    var portals = r.operator.lookup_name(name);
+
+    if(portals.length === 0 || !portals[0].json.feed[ref]){
+      return;
+    }
+
+    var entry = portals[0].entries()[ref];
+    if (entry) entry.big();
+  }
+
   this.commands.night_mode = function(p, option)
   {
     var html = document.getElementsByTagName("html")[0];


### PR DESCRIPTION
Clicking on an image enlarges the picture.

![image](https://user-images.githubusercontent.com/1200380/32995456-d22f1202-cd74-11e7-99e5-af31753a0358.png)

You can still scroll down to the entry + thread.

![image](https://user-images.githubusercontent.com/1200380/32995457-ddb3f322-cd74-11e7-9821-fd8bf9ffba1e.png)

It should work with many `custom.css` themes out of the box:

![image](https://user-images.githubusercontent.com/1200380/32995462-f318e9de-cd74-11e7-8b09-44f0085cf8bb.png)

Code-wise, the feed now has got `bigpicture_show`, `_hide`, `_toggle`, `_refresh` and `is_bigpicture`. `_show` and `_toggle` take either the raw HTML to enlarge, or a generator function (used again on `refresh`, useful for entries).

CSS-wise, it's a horrible mess depending on constants:
```css
/* In case questions arise:
 * Top is: Center of view = (.entry.top) - 50vh + entry peeking height
 * The maximum height is: view height - operator height - entry peeking height - padding
 * This is horrible.
 * -ade
 */
body #feed .bigpicture > .entry .media { position: absolute; top: calc(-50vh + 60px); left: 50%; margin: 0; transform: translate(-50%, -50%); max-width: calc(100vw - 30px); max-height: calc(100vh - 60px - 60px - 30px); }

```

... but hell, it's a beautiful mess.