### PR TITLE
Implement basic changelog & service messages in feed

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -8,6 +8,7 @@
   --rune-feed-quote: "+";
   --rune-feed-mention: ":";
 
+  --rune-portal-rotonde: "$";
   --rune-portal-self: "@";
   --rune-portal-both: "@";
   --rune-portal-follow: "~";
@@ -139,6 +140,7 @@ body #operator #icon:hover { opacity: 0.5 }
 .rune.rune-feed.rune-feed-quote:after { content: var(--rune-feed-quote); }
 .rune.rune-feed.rune-feed-mention:after { content: var(--rune-feed-mention); }
 
+.rune.rune-portal.rune-portal-rotonde:after { content: var(--rune-portal-rotonde); }
 .rune.rune-portal.rune-portal-self:after { content: var(--rune-portal-self); }
 .rune.rune-portal.rune-portal-both:after { content: var(--rune-portal-both); }
 .rune.rune-portal.rune-portal-follow:after { content: var(--rune-portal-follow); }

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -103,7 +103,7 @@ function Entry(data,host)
         title += "\n" + desc;
     }
     var url;
-    if (this.host.url == r.client_url) {
+    if (this.host.url === r.client_url || this.host.url === "$rotonde") {
       url = r.client_url + "/media/logo.svg";
     } else {
       url = this.host.url + "/media/content/icon.svg";      
@@ -116,7 +116,7 @@ function Entry(data,host)
     var html = ""
 
     var a_attr = "href='"+this.host.url+"'";
-    if (this.host === r.home.feed.portal_rotonde) {
+    if (this.host.url === r.client_url || this.host.url === "$rotonde") {
       a_attr = "style='cursor: pointer;' data-operation='filter:"+this.host.json.name+"'";
     }
     html += "<t class='portal'><a "+a_attr+">"+this.host.relationship()+r.escape_html(this.host.json.name)+"</a> "+this.rune()+" ";
@@ -125,7 +125,7 @@ function Entry(data,host)
       for(i in this.target){
         if(this.target[i]){
           var a_attr = "href='" + r.escape_attr(this.target[i]) + "'";
-          if (this.target[i] === r.client_url) {
+          if (this.target[i] === r.client_url || this.target[i] === "$rotonde") {
             a_attr = "style='cursor: pointer;' data-operation='filter:"+r.home.feed.portal_rotonde.json.name+"'";
           }
           html += "<a "+a_attr+">" + r.escape_html(portal_from_hash(this.target[i].toString())) + "</a>";
@@ -172,7 +172,7 @@ function Entry(data,host)
       html += "<div class='entry "+(this.whisper ? 'whisper' : '')+" "+(this.is_mention ? 'mention' : '')+"'>";
       html += this.icon();
       var a_attr = "href='"+this.host.url+"'";
-      if (this.host.url == r.client_url) {
+      if (this.host.url === r.client_url || this.host.url === "$rotonde") {
         a_attr = "style='cursor: pointer;' data-operation='filter:"+this.host.json.name+"'";
       }
       html += "<t class='portal'><a "+a_attr+"'>"+r.escape_html(portal_from_hash(this.host.url.toString()))+"</a> "+this.rune()+" </t>";

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -103,7 +103,7 @@ function Entry(data,host)
         title += "\n" + desc;
     }
     var url;
-    if (this.host === r.home.feed.portal_rotonde) {
+    if (this.host.url == r.client_url) {
       url = r.client_url + "/media/logo.svg";
     } else {
       url = this.host.url + "/media/content/icon.svg";      
@@ -115,12 +115,20 @@ function Entry(data,host)
   {
     var html = ""
 
-    html += "<t class='portal'><a href='"+this.host.url+"'>"+this.host.relationship()+r.escape_html(this.host.json.name)+"</a> "+this.rune()+" ";
+    var a_attr = "href='"+this.host.url+"'";
+    if (this.host === r.home.feed.portal_rotonde) {
+      a_attr = "style='cursor: pointer;' data-operation='filter:"+this.host.json.name+"'";
+    }
+    html += "<t class='portal'><a "+a_attr+">"+this.host.relationship()+r.escape_html(this.host.json.name)+"</a> "+this.rune()+" ";
 
     if(!this.expanded){
       for(i in this.target){
         if(this.target[i]){
-          html += "<a href='" + r.escape_attr(this.target[i]) + "'>" + r.escape_html(portal_from_hash(this.target[i].toString())) + "</a>";
+          var a_attr = "href='" + r.escape_attr(this.target[i]) + "'";
+          if (this.target[i] === r.client_url) {
+            a_attr = "style='cursor: pointer;' data-operation='filter:"+r.home.feed.portal_rotonde.json.name+"'";
+          }
+          html += "<a "+a_attr+">" + r.escape_html(portal_from_hash(this.target[i].toString())) + "</a>";
         }else{
           html += "...";
         }
@@ -163,7 +171,11 @@ function Entry(data,host)
     if(recursive){
       html += "<div class='entry "+(this.whisper ? 'whisper' : '')+" "+(this.is_mention ? 'mention' : '')+"'>";
       html += this.icon();
-      html += "<t class='portal'><a href='"+this.host.url+"'>"+r.escape_html(portal_from_hash(this.host.url.toString()))+"</a> "+this.rune()+" </t>";
+      var a_attr = "href='"+this.host.url+"'";
+      if (this.host.url == r.client_url) {
+        a_attr = "style='cursor: pointer;' data-operation='filter:"+this.host.json.name+"'";
+      }
+      html += "<t class='portal'><a "+a_attr+"'>"+r.escape_html(portal_from_hash(this.host.url.toString()))+"</a> "+this.rune()+" </t>";
       html += "<c class='timestamp' title='"+this.localtime()+"'>"+timeSince(this.timestamp)+" ago</c><hr />";
       html += "<t class='message' dir='auto'>"+(this.formatter(this.message))+"</t><br/></div>";
       if(this.quote){ html += this.quote.thread(recursive, thread_id); }

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -102,7 +102,13 @@ function Entry(data,host)
     if (desc){
         title += "\n" + desc;
     }
-    return "<a href='"+this.host.url+"' title='"+ title +"'><img class='icon' src='"+this.host.url+"/media/content/icon.svg'></a>";
+    var url;
+    if (this.host === r.home.feed.portal_rotonde) {
+      url = r.client_url + "/media/logo.svg";
+    } else {
+      url = this.host.url + "/media/content/icon.svg";      
+    }
+    return "<a href='"+this.host.url+"' title='"+ title +"'><img class='icon' src='"+url+"'></a>";
   }
 
   this.header = function()

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -49,6 +49,7 @@ function Feed(feed_urls)
   
   this.queue = [];
   this.portals = [];
+  this.portal_rotonde = null;
 
   this.urls = {};
   this.filter = "";
@@ -79,6 +80,9 @@ function Feed(feed_urls)
   this.start = function()
   {
     this.queue = [r.home.portal.url].concat(r.home.portal.json.port);
+    
+    new Portal(r.client_url).connect_service();
+
     this.connect();
   }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -577,6 +577,8 @@ function has_hash(hashes_a, hashes_b)
 
 function portal_from_hash(url)
 {
+  if (url.length > 0 && url[0] == "$") return url;
+  
   var hash = to_hash(url);
 
   var portal = r.home.feed.get_portal(hash);

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -233,6 +233,9 @@ function Operator(el)
 
     var quote = portals[0].json.feed[ref];
     var target = portals[0].url;
+    if (target === r.client_url) {
+      target = "$rotonde";
+    }
 
     var media = portals[0].json.feed[ref].media;
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -62,6 +62,27 @@ function Portal(url)
     setTimeout(r.home.feed.next, r.home.feed.connection_delay);
   }
 
+  this.connect_service = async function()
+  {
+    console.log('connecting to rotonde client service messages: ', p.url);
+
+    try {
+      p.file = await promiseTimeout(p.archive.readFile('/service.json', {timeout: 2000}), 2000);
+    } catch (err) {
+      console.log('connection failed: ', p.url);
+      r.home.feed.next();
+      return;
+    } // Bypass slow loading feeds
+
+    try {
+      p.json = JSON.parse(p.file);
+      p.file = null;
+      r.home.feed.portals.push(r.home.feed.portal_rotonde = this);
+    } catch (err) {
+      console.log('parsing failed: ', p.url);
+    }
+  }
+
   this.discover = async function()
   {
     console.log('connecting to: ', p.url);
@@ -147,6 +168,7 @@ function Portal(url)
 
   this.relationship = function(target = r.home.portal.hashes_set())
   {
+    if (this === r.home.feed.portal_rotonde) return create_rune("portal", "rotonde");
     if (has_hash(this, target)) return create_rune("portal", "self");
     if (has_hash(this.json.port, target)) return create_rune("portal", "both");
 

--- a/service.json
+++ b/service.json
@@ -1,0 +1,20 @@
+{
+  "name": "rotonde",
+  "desc": "",
+  "port": [],
+  "feed": [
+    {
+      "message": "{_Welcome to #rotonde, a decentralized social network. Share your dat:// url with others and add theirs into the input bar to get started._}",
+      "timestamp": 0,
+      "media": "",
+      "target": []
+    },
+    {
+      "message": "{*Rotonde 0.2.5*}\n- Introduced \"service updates\" and changelogs. Hello, World!",
+      "timestamp": 1511135422905,
+      "media": "",
+      "target": []
+    }
+  ],
+  "site": "https://github.com/Rotonde/"
+}


### PR DESCRIPTION
rotonde-client now has got a `service.json` for any service messages, i.e. changelog entries.

![image](https://user-images.githubusercontent.com/1200380/32997381-af313a80-cd8f-11e7-94d6-7cbf2085b0b6.png)

This also adds back the "welcome" message and adds the option to `filter:rotonde` (suggested action when clicking on `$rotonde`):

![image](https://user-images.githubusercontent.com/1200380/32997391-cb1e5dd6-cd8f-11e7-89d6-af1ef13c1c22.png)

Quoting is functional and is handled properly... as long as `r.client_url` stays the same.

~~Possible fix: When quoting `$rotonde` messages, replace the URL with `$rotonde`, functional across portals with different client forks.~~  
Done.