### PR TITLE
Escape closes big picture, clicking on entry doesn't

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -114,7 +114,8 @@ function Rotonde(client_url)
     console.info("Start")
     document.body.appendChild(this.el);
     document.addEventListener('mousedown',r.mouse_down, false);
-
+    document.addEventListener('keydown',r.key_down, false);
+    
     this.operator = new Operator();
     this.operator.install(this.el);
 
@@ -130,6 +131,13 @@ function Rotonde(client_url)
     r.operator.inject(e.target.getAttribute("data-operation"));
     if(!e.target.getAttribute("data-validate")){ return; }
     r.operator.validate();
+  }
+
+  this.key_down = function(e)
+  {
+    if (e.which === 27) { // ESC
+      r.home.feed.bigpicture_hide();
+    }
   }
 
   this.reset = function()

--- a/rotonde.js
+++ b/rotonde.js
@@ -137,6 +137,11 @@ function Rotonde(client_url)
   {
     if (e.which === 27) { // ESC
       r.home.feed.bigpicture_hide();
+    } else if (e.which === 116) { // F5
+      r.operator.commands.portals_refresh();
+      r.home.update();      
+      r.home.feed.refresh("hit F5");
+      e.preventDefault();
     }
   }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -430,8 +430,6 @@ function Feed(feed_urls)
     
     this.bigpicture_el.setAttribute("data-operation", "big");
     this.bigpicture_el.setAttribute("data-validate", "true");
-    this.bigpicture_el.children[0].setAttribute("data-operation", "big");
-    this.bigpicture_el.children[0].setAttribute("data-validate", "true");
 
     if (!refreshing)
       window.scrollTo(0, 0);


### PR DESCRIPTION
Pressing the ESC key in big picture now closes it, while clicking on an empty space inside the entry won't close it anymore.

Also, pressing F5 now refreshes the feed. Beaker didn't even refresh the page ¯\\\_(ツ)\_/¯