### PR TITLE
Add very basic "event" handling in Portal.js; Build sameAs on it

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -29,14 +29,14 @@ function Entry(data,host)
     if(data.quote && this.target && this.target[0]){
       var icon = this.target[0].replace(/\/$/, "") + "/media/content/icon.svg"
       // set the source's icon for quotes of remotes
-      if (host && host.json && host.json.sameAs && host.json.sameAs.indexOf(this.target[0]) >= 0) {
+      if (host && host.json && host.json.sameAs && has_hash(host.json.sameAs, this.target[0])) {
         icon = host.icon
       }
       var dummy_portal = {"url":this.target[0], "icon": icon, "json":{"name":r.escape_html(portal_from_hash(this.target[0].toString())).substring(1)}};
       this.quote = new Entry(data.quote, dummy_portal);
     }
   
-    this.is_seed = this.host ? r.home.portal.json.port.indexOf(this.host.url) > -1 : false;
+    this.is_seed = this.host && has_hash(r.home.portal.json.port, this.host.url);
   }
   this.update(data, host);
 
@@ -363,8 +363,8 @@ function Entry(data,host)
         space = m.length;
       var word = m.substring(c, space);
 
-      if (word.length > 1 && word[0] == "@") {
-        var name_match = r.operator.name_pattern.exec(word);
+      var name_match;
+      if (word.length > 1 && word[0] == "@" && (name_match = r.operator.name_pattern.exec(word))) {
         var remnants = word.substr(name_match[0].length);
         if (name_match[1] == r.home.portal.json.name) {
           n += "<t class='highlight'>"+name_match[0]+"</t>"+remnants;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -139,7 +139,11 @@ function Feed(feed_urls)
       return;
     }
 
-    var url = r.home.feed.queue[0];
+    var entry = r.home.feed.queue[0];
+    var url = entry;
+    if (entry.url) {
+      url = entry.url;
+    }
 
     r.home.feed.queue = r.home.feed.queue.slice(1);
 
@@ -151,8 +155,12 @@ function Feed(feed_urls)
       r.home.feed.next();
       return;
     }
-    // if everything went well loading the portal, let's try to load its remotes
-    portal.connect().then(portal.load_remotes);
+
+    if (entry.oncreate)
+      portal.fire(entry.oncreate);
+    if (entry.onparse)
+      portal.onparse.push(entry.onparse);
+    portal.connect();
     r.home.feed.update_log();
   }
 
@@ -176,6 +184,10 @@ function Feed(feed_urls)
     var hashes = portal.hashes();
     for (var id in hashes) {
       this.__get_portal_cache__[hashes[id]] = portal;      
+    }
+
+    if (!portal.is_remote) {
+      portal.load_remotes();
     }
 
     // Invalidate the collected network cache and recollect.
@@ -263,6 +275,8 @@ function Feed(feed_urls)
           var portal = r.home.feed.portals[id];
           await portal.refresh();
         }
+        if (r.home.feed.portal_rotonde)
+          await r.home.feed.portal_rotonde.connect_service();
         r.home.feed.refresh('delayed: ' + why);
       }, 750);
       return;
@@ -284,7 +298,9 @@ function Feed(feed_urls)
       var portal = r.home.feed.portals[id];
       entries.push.apply(entries, portal.entries());
     }
-
+    if (r.home.feed.portal_rotonde)
+      entries.push.apply(entries, r.home.feed.portal_rotonde.entries());
+    
     this.mentions = 0;
     this.whispers = 0;
 
@@ -320,7 +336,7 @@ function Feed(feed_urls)
     }
 
     var now = new Date();
-    var entries_now = new Set();
+    var entries_now = [];
     for (id in sorted_entries){
       var entry = sorted_entries[id];
 
@@ -339,7 +355,7 @@ function Feed(feed_urls)
         c = -2;
       var elem = !entry ? null : entry.to_element(timeline, c, cmin, cmax, coffset);
       if (elem != null) {
-        entries_now.add(entry);
+        entries_now.push(entry);
       }
       if (c >= 0)
         ca++;
@@ -348,7 +364,7 @@ function Feed(feed_urls)
     // Remove any "zombie" entries - removed entries not belonging to any portal.
     for (id in this.entries_prev) {
       var entry = this.entries_prev[id];
-      if (entries_now.has(entry))
+      if (entries_now.indexOf(entry) > -1)
         continue;
       entry.remove_element();
     }

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -163,9 +163,6 @@ function Operator(el)
     if(r.home.portal.json.port.indexOf(path) > -1){
       r.home.portal.json.port.splice(r.home.portal.json.port.indexOf(path), 1);
     }
-    else if(r.home.portal.json.port.indexOf(path+"/") > -1){
-      r.home.portal.json.port.splice(r.home.portal.json.port.indexOf(path+"/"), 1);
-    }
     else{
       console.log("could not find",path)
     }
@@ -177,7 +174,6 @@ function Operator(el)
         r.home.feed.portals[id].id = id;
       }
       portal.badge_remove();
-      portal.entries_remove();
     }
 
     r.home.save();
@@ -189,12 +185,12 @@ function Operator(el)
     var remote = p;
     if(remote.slice(-1) !== "/") { remote += "/" }
 
-    for(id in r.home.portal.json.sameAs) {
-      var port_url = r.home.portal.json.sameAs[id];
-      if(port_url.indexOf(remote) > -1){
-        return;
-      }
-    }
+    if (!r.home.portal.json.sameAs)
+      r.home.portal.json.sameAs = [];
+    
+    if (has_hash(r.home.portal.json.sameAs, remote))
+      return;
+
     // create the array if it doesn't exist
     if (!r.home.portal.json.sameAs) { r.home.portal.json.sameAs = [] }
     r.home.portal.json.sameAs.push(remote);
@@ -212,6 +208,9 @@ function Operator(el)
     var remote = p;
     if(remote.slice(-1) !== "/") { remote += "/" }
 
+    if (!r.home.portal.json.sameAs)
+      r.home.portal.json.sameAs = [];
+
     // Remove
     if (r.home.portal.json.sameAs.indexOf(remote) > -1) {
       r.home.portal.json.sameAs.splice(r.home.portal.json.sameAs.indexOf(remote), 1);
@@ -221,17 +220,15 @@ function Operator(el)
     }
 
     var portal = r.home.feed.get_portal(remote);
-    if (portal) {
+    if (portal && portal.is_remote) {
       r.home.feed.portals.splice(portal.id, 1)[0];
       for (var id in r.home.feed.portals) {
         r.home.feed.portals[id].id = id;
       }
-      portal.badge_remove();
-      portal.entries_remove();
     }
 
     r.home.save();
-    r.home.feed.refresh("unfollowing: "+option);
+    r.home.feed.refresh("mirroring: "+option);
   }
 
   this.commands.dat = function(p,option)
@@ -674,6 +671,8 @@ function Operator(el)
 
   this.lookup_name = function(name)
   {
+    if (r.home.feed.portal_rotonde && name === r.home.feed.portal_rotonde.json.name)
+      return [r.home.feed.portal_rotonde];
     // We return an array since multiple people might be using the same name.
     var results = [];
     for(var url in r.home.feed.portals){

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -270,8 +270,7 @@ function Operator(el)
   this.commands.quote = function(p,option)
   {
     var message = p;
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -409,8 +408,7 @@ function Operator(el)
 
   this.commands.expand = function(p, option)
   {
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -424,8 +422,7 @@ function Operator(el)
 
   this.commands.collapse = function(p, option)
   {
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -444,8 +441,7 @@ function Operator(el)
       return;
     }
 
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -680,6 +676,13 @@ function Operator(el)
       if(portal.json.name === name){ results.push(portal); }
     }
     return results;
+  }
+
+  this.split_nameref = function(option)
+  {
+    var index = option.lastIndexOf("-");
+    if (index < 0) return;
+    return { name: option.substring(0, index), ref: parseInt(option.substring(index + 1)) };
   }
 }
 


### PR DESCRIPTION
Additionally replaces a few `indexOf`s with `has_hash`, fixes zombie posts hanging around and removes $rotonde from the Portals tab (those fixes could be separated and applied to master, but aren't critical).

Portal now has got a basic `onparse` handler array, which should contain functions in the format of `(json) => {...; return true / false;}`, `true` meaning that the portal will be registered, `false` meaning that the portal will be ignored. `this` is the portal the handler's running against at the moment.

The connection queue now accepts objects with `url` and optional `oncreate` and `onparse` handlers. `oncreate` allows setting `is_remote = true;` early enough.