### PR TITLE
Fix quoting from portals with - in name

### DIFF
--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -229,8 +229,7 @@ function Operator(el)
   this.commands.quote = function(p,option)
   {
     var message = p.trim();
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -356,8 +355,7 @@ function Operator(el)
 
   this.commands.expand = function(p, option)
   {
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -371,8 +369,7 @@ function Operator(el)
 
   this.commands.collapse = function(p, option)
   {
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -391,8 +388,7 @@ function Operator(el)
       return;
     }
 
-    var name = option.split("-")[0];
-    var ref = parseInt(option.split("-")[1]);
+    var {name, ref} = r.operator.split_nameref(option);
 
     var portals = r.operator.lookup_name(name);
 
@@ -625,6 +621,13 @@ function Operator(el)
       if(portal.json.name === name){ results.push(portal); }
     }
     return results;
+  }
+
+  this.split_nameref = function(option)
+  {
+    var index = option.lastIndexOf("-");
+    if (index < 0) return;
+    return { name: option.substring(0, index), ref: parseInt(option.substring(index + 1)) };
   }
 }
 


### PR DESCRIPTION
Cherry-picked this from #157 as it's a little more critical than the other fixes.

Quoting f.e. `0x0ade/test-a-3` (3rd message from 0x0ade/test-a) was impossible before. The options string was split, [0] was used as the portal name (`0x0ade/test`) and [1] was used as the ref id (`a`). This PR replaces that with

```js
var {name, ref} = r.operator.split_nameref(option);
```

where `split_nameref` uses everything past the last `-` as the ref id.