### PR TITLE
Implements sameAs to use Rotonde from multiple machines

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -484,9 +484,18 @@ function Entry(data,host)
     }
 
     if(this.target && this.target.length > 0){
-      return has_hash(r.home.portal, this.target);
+      var has_mention = false;
+      var ports = [r.home.portal.dat];
+      if (r.home.portal.json && r.home.portal.json.sameAs) {
+        ports = ports.concat(r.home.portal.json.sameAs);
+      }
+      ports.forEach((port) => {
+        this.target.forEach((t) => {
+          has_mention = has_mention || t === port;
+        })
+      })
+      return has_mention;
     }
-
     return false;
   }
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -483,17 +483,12 @@ function Entry(data,host)
       return true;
     }
 
-    if(this.target && this.target.length > 0){
-      var has_mention = false;
-      var ports = [r.home.portal.dat];
+    // check for mentions of our portal or of one of our remotes in sameAs
+    if (this.target && this.target.length > 0) {
+      var has_mention = has_hash(r.home.portal, this.target);
       if (r.home.portal.json && r.home.portal.json.sameAs) {
-        ports = ports.concat(r.home.portal.json.sameAs);
+        has_mention = has_mention || has_hash(r.home.portal.json.sameAs, this.target);
       }
-      ports.forEach((port) => {
-        this.target.forEach((t) => {
-          has_mention = has_mention || t === port;
-        })
-      })
       return has_mention;
     }
     return false;

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -27,7 +27,7 @@ function Entry(data,host)
   
     this.quote = data.quote;
     if(data.quote && this.target && this.target[0]){
-      var dummy_portal = {"url":this.target[0],"json":{"name":r.escape_html(portal_from_hash(this.target[0].toString())).substring(1)}};
+      var dummy_portal = {"url":this.target[0], "icon": this.target[0].replace(/\/$/, "") + "/media/content/icon.svg", "json":{"name":r.escape_html(portal_from_hash(this.target[0].toString())).substring(1)}};
       this.quote = new Entry(data.quote, dummy_portal);
     }
   

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -102,7 +102,7 @@ function Entry(data,host)
     if (desc){
         title += "\n" + desc;
     }
-    return "<a href='"+this.host.url+"' title='"+ title +"'><img class='icon' src='"+this.host.url+"/media/content/icon.svg'></a>";
+    return "<a href='"+this.host.url+"' title='"+ title +"'><img class='icon' src='"+this.host.icon+"'></a>";
   }
 
   this.header = function()

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -29,8 +29,8 @@ function Entry(data,host)
     if(data.quote && this.target && this.target[0]){
       var icon = this.target[0].replace(/\/$/, "") + "/media/content/icon.svg"
       // set the source's icon for quotes of remotes
-      if (host.json.sameAs && host.json.sameAs.indexOf(this.target[0]) >= 0) {
-        var icon = host.icon
+      if (host && host.json && host.json.sameAs && host.json.sameAs.indexOf(this.target[0]) >= 0) {
+        icon = host.icon
       }
       var dummy_portal = {"url":this.target[0], "icon": icon, "json":{"name":r.escape_html(portal_from_hash(this.target[0].toString())).substring(1)}};
       this.quote = new Entry(data.quote, dummy_portal);

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -138,7 +138,8 @@ function Feed(feed_urls)
       r.home.feed.next();
       return;
     }
-    portal.connect()
+    // if everything went well loading the portal, let's try to load its remotes
+    portal.connect().then(portal.load_remotes)
     r.home.feed.update_log();
   }
 

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -152,7 +152,7 @@ function Feed(feed_urls)
       return;
     }
     // if everything went well loading the portal, let's try to load its remotes
-    portal.connect().then(portal.load_remotes)
+    portal.connect().then(portal.load_remotes);
     r.home.feed.update_log();
   }
 

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -198,8 +198,12 @@ function Operator(el)
     // create the array if it doesn't exist
     if (!r.home.portal.json.sameAs) { r.home.portal.json.sameAs = [] }
     r.home.portal.json.sameAs.push(remote);
-    r.home.feed.queue.push(remote);
-    r.home.feed.connect();
+    try {
+      var remote_portal = new Portal(remote)
+      remote_portal.start().then(r.home.portal.load_remotes)
+    } catch (err) {
+      console.error("Error when connecting to remote", err)
+    }
     r.home.save();
   }
 

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -195,6 +195,8 @@ function Operator(el)
         return;
       }
     }
+    // create the array if it doesn't exist
+    if (!r.home.portal.json.sameAs) { r.home.portal.json.sameAs = [] }
     r.home.portal.json.sameAs.push(remote);
     r.home.feed.queue.push(remote);
     r.home.feed.connect();

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -184,6 +184,50 @@ function Operator(el)
     r.home.feed.refresh("unfollowing: "+option);
   }
 
+  this.commands.mirror = function(p,option)
+  {
+    var remote = p;
+    if(remote.slice(-1) !== "/") { remote += "/" }
+
+    for(id in r.home.portal.json.sameAs) {
+      var port_url = r.home.portal.json.sameAs[id];
+      if(port_url.indexOf(remote) > -1){
+        return;
+      }
+    }
+    r.home.portal.json.sameAs.push(remote);
+    r.home.feed.queue.push(remote);
+    r.home.feed.connect();
+    r.home.save();
+  }
+
+  this.commands.unmirror = function(p,option)
+  {
+    var remote = p;
+    if(remote.slice(-1) !== "/") { remote += "/" }
+
+    // Remove
+    if (r.home.portal.json.sameAs.indexOf(remote) > -1) {
+      r.home.portal.json.sameAs.splice(r.home.portal.json.sameAs.indexOf(remote), 1);
+    } else {
+      console.log("could not find",remote);
+      return;
+    }
+
+    var portal = r.home.feed.get_portal(remote);
+    if (portal) {
+      r.home.feed.portals.splice(portal.id, 1)[0];
+      for (var id in r.home.feed.portals) {
+        r.home.feed.portals[id].id = id;
+      }
+      portal.badge_remove();
+      portal.entries_remove();
+    }
+
+    r.home.save();
+    r.home.feed.refresh("unfollowing: "+option);
+  }
+
   this.commands.dat = function(p,option)
   {
     option = to_hash(option);

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -106,7 +106,8 @@ function Portal(url)
         oncreate: function() {
           this.is_remote = true;
           this.remote_parent = p;
-          this.icon = p.url + "/media/content/icon.svg";
+          var hash = p.hashes()[0]
+          this.icon = "dat://" + hash + "/media/content/icon.svg";
         },
         onparse: function(json) {
           this.json.name = `${p.json.name}=${json.name}`

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -77,7 +77,7 @@ function Portal(url)
             if (remote.json.sameAs && remote.json.sameAs.indexOf(p.dat) >= 0) {
               console.log(remote.dat + "has a mutual relationship w/ us :)")
               // set remote name
-              remote.json.name = `${p.json.name}@${remote.json.name}`
+              remote.json.name = `${p.json.name}=${remote.json.name}`
               remote.icon = p.url + "/media/content/icon.svg"
               r.home.feed.register(remote);
             } else {

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -110,6 +110,14 @@ function Portal(url)
         },
         onparse: function(json) {
           this.json.name = `${p.json.name}=${json.name}`
+          if (has_hash(r.home.portal, this.remote_parent)) {
+            Array.prototype.push.apply(r.home.feed.queue, this.json.port.map((port) => {
+              return {
+                url: port,
+                onparse: function() { return true}
+              }
+            }))
+          }
           return this.json.sameAs && has_hash(this.json.sameAs, p.hashes());
         }
       }

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -119,7 +119,10 @@ function Portal(url)
               }
             }))
           }
-          return this.json.sameAs && has_hash(this.json.sameAs, p.hashes());
+          if (this.json && this.json.sameAs) {
+            return has_hash(this.json.sameAs, p.hashes());
+          }
+          return false
         }
       }
     }));

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -3,8 +3,8 @@ function Portal(url)
   var p = this;
 
   this.url = url;
+  this.icon = url.replace(/\/$/, "") + "/media/content/icon.svg";
   this.file = null;
-  this.icon = url + "/media/content/icon.svg"
   this.json = null;
   this.archive = new DatArchive(this.url);
   // Resolve "masked" (f.e. hashbase) dat URLs to "hashed" (dat://0123456789abcdef/) one.
@@ -74,7 +74,7 @@ function Portal(url)
             if (remote.json.sameAs && remote.json.sameAs.indexOf(p.dat) >= 0) {
               console.log(remote.dat + "has a mutual relationship w/ us :)")
               // set remote name
-              remote.json.name = `${p.json.name} (${remote.json.name})`
+              remote.json.name = `${p.json.name}@${remote.json.name}`
               remote.icon = p.url + "/media/content/icon.svg"
               r.home.feed.register(remote);
             } else {
@@ -89,7 +89,7 @@ function Portal(url)
       })
 
       Promise.all(remote_promises).then(() => {
-        console.log("all remotes have been handled?")
+        console.log("all remotes appear to have been handled?")
       })
     }
   }

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -4,6 +4,7 @@ function Portal(url)
 
   this.url = url;
   this.file = null;
+  this.icon = url + "/media/content/icon.svg"
   this.json = null;
   this.archive = new DatArchive(this.url);
   // Resolve "masked" (f.e. hashbase) dat URLs to "hashed" (dat://0123456789abcdef/) one.
@@ -64,7 +65,6 @@ function Portal(url)
 
   this.load_remotes = async function() {
     if (p.json && p.json.sameAs && p.json.sameAs.length > 0) {
-      // naive solution while testing
       var remote_promises = p.json.sameAs.map((remote_url) => {
         return new Promise((resolve, reject) => {
           console.log("remote url", remote_url)
@@ -75,7 +75,7 @@ function Portal(url)
               console.log(remote.dat + "has a mutual relationship w/ us :)")
               // set remote name
               remote.json.name = `${p.json.name} (${remote.json.name})`
-              // remote.url = p.url
+              remote.icon = p.url + "/media/content/icon.svg"
               r.home.feed.register(remote);
             } else {
               console.log(remote.dat + " wasn't a mutual with us :<")

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -62,6 +62,38 @@ function Portal(url)
     setTimeout(r.home.feed.next, r.home.feed.connection_delay);
   }
 
+  this.load_remotes = async function() {
+    if (p.json && p.json.sameAs && p.json.sameAs.length > 0) {
+      // naive solution while testing
+      var remote_promises = p.json.sameAs.map((remote_url) => {
+        return new Promise((resolve, reject) => {
+          console.log("remote url", remote_url)
+          var remote = new Portal(remote_url)
+          remote.start().then(() => {
+            console.log("loaded remote")
+            if (remote.json.sameAs && remote.json.sameAs.indexOf(p.dat) >= 0) {
+              console.log(remote.dat + "has a mutual relationship w/ us :)")
+              // set remote name
+              remote.json.name = `${p.json.name} (${remote.json.name})`
+              // remote.url = p.url
+              r.home.feed.register(remote);
+            } else {
+              console.log(remote.dat + " wasn't a mutual with us :<")
+            }
+          }).then(resolve).catch((err) => {
+            console.error("something went wrong when loading remotes")
+            console.error(err)
+            reject()
+          })
+        })
+      })
+
+      Promise.all(remote_promises).then(() => {
+        console.log("all remotes have been handled?")
+      })
+    }
+  }
+
   this.discover = async function()
   {
     console.log('connecting to: ', p.url);


### PR DESCRIPTION
As described in [#147](https://github.com/Rotonde/rotonde-client/issues/147#issuecomment-345389579) `sameAs` is an extension to portal.json. 

It adds an array `sameAs` that contains entries to other portals. If those portals in turn have your portal in their `sameAs` arrays, you are considered **remotes** of each other. 

The entire point is to decouple your Rotonde portal from a single machine. Using this feature you can now:
* see the same feed as your remotes
* others following your portal will see the posts you make **from remotes**
* mentions to either the source portal or its remotes will be visible in the mentions tab

#### Start using it:
If your main portal is `dat://7f2ee...0c5/` and your work computer has a portal at `dat://3ba71...829/`

1. Visit your main portal at `dat://7f2ee...0c5/` and run `mirror dat://3ba71...829/`
1. Visit your work portal at `dat://3ba71...829/` and run `mirror dat://7f2ee...0c5/`
1. You're done! You can now Rotonde from any of the machines with ease.

Remove remotes using the **unmirror** command:
`unmirror dat://7f2ee...0c5/` this severs the link between remotes.

Thanks to @0x0ade for some back and forth across twitter, rotonde and github! :~