### PR TITLE
Add oembed support

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -48,8 +48,10 @@ body #feed .entry .thread .message a:first-child { font-weight: bold; color:#000
 body #feed .entry.whisper .thread .message a:first-child { color:#fff; }
 body #feed .entry .thread .message { padding:0px 40px 0px 70px; color:#777; margin-bottom:10px; font-size:11pt; font-style:italic; position: relative; min-height:60px; max-width: 350px}
 body #feed .entry .thread .message a img { top:0px; left:0px; width:50px; height:50px;}
-body #feed .entry .thread .expand { padding: 5px 0px;font-size: 12px;color: #aaa;border-top: 1px solid #ddd;display: block;margin-right: 30px; margin-top:10px;}
-body #feed .entry .thread .expand:hover { color:#000; cursor:pointer; }
+body #feed .entry .thread .expand,
+body #feed .entry .media.embed .expand { padding: 5px 0px;font-size: 12px;color: #aaa;border-top: 1px solid #ddd;display: block;margin-right: 30px; margin-top:10px;}
+body #feed .entry .thread .expand:hover,
+body #feed .entry .media.embed .expand:hover { color:#000; cursor:pointer; }
 body #feed .entry .thread .entry { background: transparent; padding-top: 0px; padding-bottom: 0px; min-height: 60px; padding-left: 70px; }
 body #feed .entry .thread .entry:hover {}
 body #feed .entry .thread .entry .message { padding: 0px 0px;margin-top: 0px;min-height: 15px;margin-bottom: 15px; }
@@ -64,7 +66,9 @@ body #feed .entry .editstamp:hover { cursor:pointer; text-decoration: underline;
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .media { position: relative; display:block; border-radius:4px; max-width: calc(100% - 30px); max-height: 400px; margin-top:15px; margin-bottom:15px; left: calc(50% - 15px); transform: translateX(-50%); }
 body #feed .entry .media.embed { }
-body #feed .entry .media.embed iframe { display:block; width: 100%; }
+body #feed .entry .media.embed iframe { display:block; width: 100%; max-height: 360px; margin-bottom: 20px; }
+body #feed .entry .media.embed .expand { margin-top: 0; }
+body #feed .entry .media.embed .expand:hover {  }
 body #feed .entry .tools { display:none; float:right; margin-right:50px; margin-top:5px; }
 body #feed .entry .tools > * { color:#aaa; cursor:pointer; display: inline-block; margin-left:5px; font-weight: bold; font-size:11px; text-transform: uppercase;}
 body #feed .entry .tools > *:hover { color: black; text-decoration: underline; }

--- a/links/main.css
+++ b/links/main.css
@@ -62,7 +62,9 @@ body #feed .entry .timestamp:hover { cursor:pointer; text-decoration: underline;
 body #feed .entry .editstamp { color:#ccc; font-size:10pt; }
 body #feed .entry .editstamp:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
-body #feed .entry .media { display:block; border-radius:4px; max-width: calc(100% - 30px); max-height: 400px; margin-top:15px; margin-bottom:15px; margin-left: calc(50% - 15px); transform: translateX(-50%); }
+body #feed .entry .media { position: relative; display:block; border-radius:4px; max-width: calc(100% - 30px); max-height: 400px; margin-top:15px; margin-bottom:15px; left: calc(50% - 15px); transform: translateX(-50%); }
+body #feed .entry .media.embed { }
+body #feed .entry .media.embed iframe { position: relative; display:block; left: calc(50%); transform: translateX(-50%); }
 body #feed .entry .tools { display:none; float:right; margin-right:50px; margin-top:5px; }
 body #feed .entry .tools > * { color:#aaa; cursor:pointer; display: inline-block; margin-left:5px; font-weight: bold; font-size:11px; text-transform: uppercase;}
 body #feed .entry .tools > *:hover { color: black; text-decoration: underline; }

--- a/links/main.css
+++ b/links/main.css
@@ -64,7 +64,7 @@ body #feed .entry .editstamp:hover { cursor:pointer; text-decoration: underline;
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .media { position: relative; display:block; border-radius:4px; max-width: calc(100% - 30px); max-height: 400px; margin-top:15px; margin-bottom:15px; left: calc(50% - 15px); transform: translateX(-50%); }
 body #feed .entry .media.embed { }
-body #feed .entry .media.embed iframe { position: relative; display:block; left: calc(50%); transform: translateX(-50%); }
+body #feed .entry .media.embed iframe { display:block; width: 100%; }
 body #feed .entry .tools { display:none; float:right; margin-right:50px; margin-top:5px; }
 body #feed .entry .tools > * { color:#aaa; cursor:pointer; display: inline-block; margin-left:5px; font-weight: bold; font-size:11px; text-transform: uppercase;}
 body #feed .entry .tools > *:hover { color: black; text-decoration: underline; }

--- a/links/main.css
+++ b/links/main.css
@@ -66,7 +66,9 @@ body #feed .entry .editstamp:hover { cursor:pointer; text-decoration: underline;
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .media { position: relative; display:block; border-radius:4px; max-width: calc(100% - 30px); max-height: 400px; margin-top:15px; margin-bottom:15px; left: calc(50% - 15px); transform: translateX(-50%); }
 body #feed .entry .media.embed { }
-body #feed .entry .media.embed iframe { display:block; width: 100%; max-height: 360px; margin-bottom: 20px; }
+body #feed .entry .media.embed .media { max-height: 360px; margin-bottom: 20px; }
+body #feed .entry .media.embed iframe.media { width: 100%; }
+body #feed .entry .media.embed iframe.media.sandbox { height: 10000px; /* Limited by max-height */ }
 body #feed .entry .media.embed .expand { margin-top: 0; }
 body #feed .entry .media.embed .expand:hover {  }
 body #feed .entry .tools { display:none; float:right; margin-right:50px; margin-top:5px; }
@@ -159,6 +161,7 @@ body.guest #operator #wrapper { display:none; }
 html.night { filter: hue-rotate(180deg) invert(); background: #111; }
 html.night body #feed .entry img.media { filter: hue-rotate(180deg) invert(); background: #666; }
 html.night body #feed .entry video.media { filter: hue-rotate(180deg) invert(); }
+html.night body #feed .entry iframe.media { filter: hue-rotate(180deg) invert(); }
 html.night ::-webkit-media-controls-panel { background: #000; }
 
 body #feed #tabs,
@@ -176,7 +179,11 @@ body #feed .bigpicture > .entry { margin: calc(100vh - 60px) auto 0 auto; width:
  * This is horrible.
  * -ade
  */
-body #feed .bigpicture > .entry .media { position: absolute; top: calc(-50vh + 60px); left: 50%; margin: 0; transform: translate(-50%, -50%); max-width: calc(100vw - 30px); max-height: calc(100vh - 60px - 60px - 30px); }
+body #feed .bigpicture > .entry > .media { position: absolute; top: calc(-50vh + 60px); left: 50%; margin: 0; transform: translate(-50%, -50%); }
+body #feed .bigpicture > .entry > .media,
+body #feed .bigpicture > .entry > .media.embed .media { max-width: calc(100vw - 30px); max-height: calc(100vh - 60px - 60px - 30px); }
+body #feed .bigpicture > .entry > .media.embed .media { display: block; margin: 0; padding: 0; }
+body #feed .bigpicture > .entry > .media.embed .expand { display: none; }
 
 body .fade-in { animation: fade-in 0.15s forwards; }
 @keyframes fade-in {

--- a/rotonde.js
+++ b/rotonde.js
@@ -5,7 +5,7 @@ function Rotonde(client_url)
 
   // SETUP
 
-  this.requirements = {style:["reset","fonts","main"],script:["util","home","portal","feed","entry","operator","oembed","oembed_providers"]};
+  this.requirements = {style:["reset","fonts","main"],script:["util","home","portal","feed","entry","operator","oembed"]};
   this.includes = {script:[]};
   this.is_owner = false;
 
@@ -72,18 +72,12 @@ function Rotonde(client_url)
 
   this.operator = null;
 
-  this.oembed = null;
-  this.oembed_providers = [];
-
   this.start = function()
   {
     console.info("Start")
     document.body.appendChild(this.el);
     document.addEventListener('mousedown',r.mouse_down, false);
     document.addEventListener('keydown',r.key_down, false);
-    
-    this.oembed = new OEmbed();
-    this.oembed.setup();
 
     this.operator = new Operator();
     this.operator.install(this.el);

--- a/rotonde.js
+++ b/rotonde.js
@@ -5,7 +5,7 @@ function Rotonde(client_url)
 
   // SETUP
 
-  this.requirements = {style:["reset","fonts","main"],script:["util","home","portal","feed","entry","operator"]};
+  this.requirements = {style:["reset","fonts","main"],script:["util","home","portal","feed","entry","operator","oembed","oembed_providers"]};
   this.includes = {script:[]};
   this.is_owner = false;
 
@@ -72,6 +72,9 @@ function Rotonde(client_url)
 
   this.operator = null;
 
+  this.oembed = null;
+  this.oembed_providers = [];
+
   this.start = function()
   {
     console.info("Start")
@@ -79,6 +82,9 @@ function Rotonde(client_url)
     document.addEventListener('mousedown',r.mouse_down, false);
     document.addEventListener('keydown',r.key_down, false);
     
+    this.oembed = new OEmbed();
+    this.oembed.setup();
+
     this.operator = new Operator();
     this.operator.install(this.el);
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -231,7 +231,7 @@ function Entry(data,host)
       html += "<div class='media embed'>";
       if (this.embed_expanded) {
         if (this.embed.resolved === undefined) { // If still resolving
-          this.embed.resolve();
+          this.embed.resolve(this);
           html += "<t class='expand preload'>Loading content...</t>";
         } else if (this.embed.resolved) { // If resolved properly
           html += "<div>" + this.embed.resolved + "</div>";

--- a/scripts/oembed.js
+++ b/scripts/oembed.js
@@ -1,0 +1,183 @@
+// This wouldn't be possible without the providers data from https://github.com/nfl/jquery-oembed-all/blob/master/jquery.oembed.js
+function OEmbedProvider(name, type, urlschemesarray, apiendpoint, extraSettings) {
+  this.name = name;
+  this.type = type; // "photo", "video", "link", "rich", null
+  this.urlschemes = urlschemesarray;
+  for (var i in this.urlschemes) {
+    this.urlschemes[i] = new RegExp(this.urlschemes[i], "i");
+  }
+  this.apiendpoint = apiendpoint;
+  this.maxWidth = 500;
+  this.maxHeight = 400;
+  extraSettings = extraSettings || {};
+
+  for (var property in extraSettings) {
+      this[property] = extraSettings[property];
+  }
+
+  this.format = this.format || "json";
+  this.callbackparameter = this.callbackparameter || "callback";
+  this.embedtag = this.embedtag || {tag: ""};
+};
+
+function OEmbed() {
+
+  this.setup = function()
+  {
+    // nop at the moment.
+  }
+
+  this.get_provider = function(url)
+  {
+    for (var i in r.oembed_providers) {
+      var provider = r.oembed_providers[i];
+      for (var j in provider.urlschemes) {
+        if (url.match(provider.urlschemes[j]))
+          return provider;
+      }
+    }
+    return null;
+  }
+
+  this.get_embed = async function(entry, url)
+  {
+    var provider = this.get_provider(url);
+    if (!provider) return null;
+
+    var src, data;
+
+    if (provider.templateRegex) {
+      // We've got a template for the provider.
+
+      if (provider.apiendpoint) {
+        src = url.replace(provider.templateRegex, provider.apiendpoint);
+        if (src.startsWith("//"))
+          src = "https:" + src;
+
+        if (provider.embedtag) {
+          // The provider makes embedding easy.
+          var embed = provider.embedtag;
+          if (embed.tag !== "iframe")
+            return null; // Flash (<embed>) and other non-iframe embeds not supported.
+  
+  
+          if (!provider.nocache)
+            src += "&_=" + Date.now();
+  
+          return `<iframe src='${escape_attr(src)}' `+
+            `width='${embed.width || "auto"}' height='${embed.height || "auto"}' `+
+            `scrolling='${embed.scrolling || "no"}' frameborder='${embed.frameborder || "0"}' `+
+            // Personally not a fan of allow-same-origin, but pages require it to work properly.
+            // TODO: Provider should contain info if allow-same-origin is required.
+            `allowfullscreen sandbox='allow-popups allow-scripts allow-same-origin' ` +
+            `/>`;
+        
+        }
+
+        // We need to request data from the endpoint and pass it through provider.templateData.
+        try {
+          data = await this.fetch_jsonp(src);
+        } catch (err) { }
+        if (!data)
+          return null;
+        return provider.templateData(data);
+      }
+
+      return url.replace(provider.templateRegex, provider.template);
+    }
+
+    // We need to request the oembed data from the provider and handle it on our own.
+
+    src = provider.apiendpoint;
+    src += src.indexOf("?") < 0 ? "?" : "&";
+    src += `format=${provider.format}&url=${encodeURIComponent(url)}`;
+
+    try {
+      data = await this.fetch_jsonp(src);
+    } catch (err) { }
+    if (!data)
+      return null;
+    
+    switch (data.type) {
+      case "photo":
+      case "file":
+        var title = "";
+        if (data.title)
+          title += data.title;
+        if (data.author_name)
+          title += (data.title ? " - " : "") + data.author_name;
+        if (data.provider_name)
+          title += ((data.title || data.author_name) ? " - " : "") + data.provider_name;
+
+        if (data.url) {
+          return entry.rmc_bigpicture("", data.url, "img", "media", `alt='${escape_attr(title)}'`, "", url);
+        } else if (data.thumbnail_url) {
+          return entry.rmc_bigpicture("", data.thumbnail_url.replace("_s", "_b"), "img", "media", `alt='${escape_attr(title)}'`, "", url);
+        } else if (data.html) {
+          return this.sandbox(data.html);
+        }
+
+        return null;
+      
+      case "video":
+      case "rich":
+          return this.sandbox(data.html);
+        
+      default:
+        if (data.html) {
+          return this.sandbox(data.html);
+        }
+
+        return null;
+    }
+    
+    return null;
+  }
+
+  this.sandbox = function(inner) {
+    if (inner.trim().startsWith("<iframe ")) {
+      // Trust that the provider returned nothing malicious.
+      return inner;
+    }
+    return `<iframe srcdoc='${escape_attr(inner)}' `+
+      `seamless `+
+      `allowfullscreen sandbox='allow-popups allow-scripts' ` +
+      `/>`;
+  }
+
+  this.fetch_jsonp = function(src, timeout = 1000) { return new Promise((resolve, reject) => {
+    if (src.startsWith("//"))
+      src = "https:" + src;
+
+    var id = __oembed_jsonp__.length;
+    
+    src += `&callback=__oembed_jsonp__[${id}]`;
+
+    var el = document.createElement("script");
+    el.type = "text/javascript";
+    el.src = src;
+    el.async = true;
+
+    var rejectout = setTimeout(() => {
+      __oembed_jsonp__[id] = null;
+      el.remove();
+      reject(new Error("jsonp request failed, timeout!"));
+    }, timeout);
+
+    __oembed_jsonp__[id] = data => {
+      clearTimeout(timeout);
+      if (!__oembed_jsonp__[id])
+        return;
+      __oembed_jsonp__[id] = null;
+      el.remove();
+      resolve(data);
+    };
+
+    document.head.appendChild(el);
+  })}
+
+}
+
+__oembed_jsonp__ = [];
+
+r.confirm("script","oembed");

--- a/scripts/oembed.js
+++ b/scripts/oembed.js
@@ -1,25 +1,3 @@
-// This wouldn't be possible without the providers data from https://github.com/nfl/jquery-oembed-all/blob/master/jquery.oembed.js
-function OEmbedProvider(name, type, urlschemesarray, apiendpoint, extraSettings) {
-  this.name = name;
-  this.type = type; // "photo", "video", "link", "rich", null
-  this.urlschemes = urlschemesarray;
-  for (var i in this.urlschemes) {
-    this.urlschemes[i] = new RegExp(this.urlschemes[i], "i");
-  }
-  this.apiendpoint = apiendpoint;
-  this.maxWidth = 500;
-  this.maxHeight = 400;
-  extraSettings = extraSettings || {};
-
-  for (var property in extraSettings) {
-      this[property] = extraSettings[property];
-  }
-
-  this.format = this.format || "json";
-  this.callbackparameter = this.callbackparameter || "callback";
-  this.embedtag = this.embedtag || {tag: ""};
-};
-
 function OEmbed() {
 
   this.setup = function()
@@ -145,7 +123,7 @@ function OEmbed() {
       `/>`;
   }
 
-  this.fetch_jsonp = function(src, timeout = 1000) { return new Promise((resolve, reject) => {
+  this.fetch_jsonp = function(src, timeout = 2000) { return new Promise((resolve, reject) => {
     if (src.startsWith("//"))
       src = "https:" + src;
 

--- a/scripts/oembed_providers.js
+++ b/scripts/oembed_providers.js
@@ -1,0 +1,283 @@
+// This is a subset of the providers list from https://github.com/nfl/jquery-oembed-all/blob/master/jquery.oembed.js
+r.oembed_providers = [
+
+  // Video
+  new OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], '//www.youtube.com/embed/$1?wmode=transparent', {
+    templateRegex: /.*(?:v\=|be\/|embed\/)([\w\-]+)&?.*/, embedtag: {tag: 'iframe', width: '425', height: '349'}
+  }),
+
+  new OEmbedProvider("xtranormal", "video", ["xtranormal\\.com/watch/.+"], "http://www.xtranormal.com/xtraplayr/$1/$2", {
+    templateRegex: /.*com\/watch\/([\w\-]+)\/([\w\-]+).*/, embedtag: {tag: 'iframe', width: '320', height: '269'}}),
+  new OEmbedProvider("scivee", "video", ["scivee.tv/node/.+"], "http://www.scivee.tv/flash/embedCast.swf?", {
+    templateRegex: /.*tv\/node\/(.+)/, embedtag: {width: '480', height: '400', flashvars: "id=$1&type=3"}}),
+  new OEmbedProvider("veoh", "video", ["veoh.com/watch/.+"], "http://www.veoh.com/swf/webplayer/WebPlayer.swf?version=AFrontend.5.7.0.1337&permalinkId=$1&player=videodetailsembedded&videoAutoPlay=0&id=anonymous", {
+    templateRegex: /.*watch\/([^\?]+).*/, embedtag: {width: '410', height: '341'}}),
+  new OEmbedProvider("gametrailers", "video", ["gametrailers\\.com/video/.+"], "http://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$2", {
+    templateRegex: /.*com\/video\/([\w\-]+)\/([\w\-]+).*/, embedtag: {width: '512', height: '288' }}),
+  new OEmbedProvider("funnyordie", "video", ["funnyordie\\.com/videos/.+"], "http://player.ordienetworks.com/flash/fodplayer.swf?", {
+    templateRegex: /.*videos\/([^\/]+)\/([^\/]+)?/, embedtag: {width: 512, height: 328, flashvars: "key=$1"}}),
+  new OEmbedProvider("collegehumour", "video", ["collegehumor\\.com/video/.+"], "http://www.collegehumor.com/moogaloop/moogaloop.swf?clip_id=$1&use_node_id=true&fullscreen=1",
+    {templateRegex: /.*video\/([^\/]+).*/, embedtag: {width: 600, height: 338}}),
+  new OEmbedProvider("metacafe", "video", ["metacafe\\.com/watch/.+"], "http://www.metacafe.com/fplayer/$1/$2.swf",
+    {templateRegex: /.*watch\/(\d+)\/(\w+)\/.*/, embedtag: {width: 400, height: 345}}),
+  new OEmbedProvider("bambuser", "video", ["bambuser\\.com\/channel\/.*\/broadcast\/.*"], "http://static.bambuser.com/r/player.swf?vid=$1",
+    {templateRegex: /.*bambuser\.com\/channel\/.*\/broadcast\/(\w+).*/, embedtag: {width: 512, height: 339 }}),
+  new OEmbedProvider("twitvid", "video", ["twitvid\\.com/.+"], "http://www.twitvid.com/embed.php?guid=$1&autoplay=0",
+    {templateRegex: /.*twitvid\.com\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider("aniboom", "video", ["aniboom\\.com/animation-video/.+"], "http://api.aniboom.com/e/$1",
+    {templateRegex: /.*animation-video\/(\d+).*/, embedtag: {width: 594, height: 334}}),
+  new OEmbedProvider("vzaar", "video", ["vzaar\\.com/videos/.+", "vzaar.tv/.+"], "http://view.vzaar.com/$1/player?",
+    {templateRegex: /.*\/(\d+).*/, embedtag: {tag: 'iframe', width: 576, height: 324 }}),
+  new OEmbedProvider("snotr", "video", ["snotr\\.com/video/.+"], "http://www.snotr.com/embed/$1",
+    {templateRegex: /.*\/(\d+).*/, embedtag: {tag: 'iframe', width: 400, height: 330}, nocache: 1 }),
+  new OEmbedProvider("youku", "video", ["v.youku.com/v_show/id_.+"], "http://player.youku.com/player.php/sid/$1/v.swf",
+    {templateRegex: /.*id_(.+)\.html.*/, embedtag: {width: 480, height: 400}, nocache: 1 }),
+  new OEmbedProvider("tudou", "video", ["tudou.com/programs/view/.+\/"], "http://www.tudou.com/v/$1/v.swf",
+    {templateRegex: /.*view\/(.+)\//, embedtag: {width: 480, height: 400}, nocache: 1 }),
+  new OEmbedProvider("embedr", "video", ["embedr\\.com/playlist/.+"], "http://embedr.com/swf/slider/$1/425/520/default/false/std?",
+    {templateRegex: /.*playlist\/([^\/]+).*/, embedtag: {width: 425, height: 520}}),
+  new OEmbedProvider("blip", "video", ["blip\\.tv/.+"], "//blip.tv/oembed/"),
+  new OEmbedProvider("animoto", "video", ["animoto.com/play/.+"], "http://animoto.com/services/oembed"),
+  new OEmbedProvider("hulu", "video", ["hulu\\.com/watch/.*"], "//www.hulu.com/api/oembed.json"),
+  new OEmbedProvider("vimeo", "video", ["www\.vimeo\.com\/groups\/.*\/videos\/.*", "www\.vimeo\.com\/.*", "vimeo\.com\/groups\/.*\/videos\/.*", "vimeo\.com\/.*"], "//vimeo.com/api/oembed.json"),
+  new OEmbedProvider("dailymotion", "video", ["dailymotion\\.com/.+"], '//www.dailymotion.com/services/oembed'),
+  new OEmbedProvider("revision3", "video", ["revision3\\.com"], "http://revision3.com/api/oembed/"),
+  new OEmbedProvider("clikthrough", "video", ["clikthrough\\.com/theater/video/\\d+"], "http://clikthrough.com/services/oembed"),
+  new OEmbedProvider("Kinomap", "video", ["kinomap\\.com/.+"], "http://www.kinomap.com/oembed"),
+  new OEmbedProvider("VHX", "video", ["vhx.tv/.+"], "http://vhx.tv/services/oembed.json"),
+  new OEmbedProvider("bambuser", "video", ["bambuser.com/.+"], "http://api.bambuser.com/oembed/iframe.json"),
+  new OEmbedProvider("vine", "video", ["vine.co/v/.*"], null,
+    {
+      templateRegex: /https?:\/\/w?w?w?.?vine\.co\/v\/([a-zA-Z0-9]*).*/,
+      template: '<iframe src="https://vine.co/v/$1/embed/postcard" width="600" height="600" allowfullscreen="true" allowscriptaccess="always" scrolling="no" frameborder="0"></iframe>' +
+        '<script async src="//platform.vine.co/static/scripts/embed.js" charset="utf-8"></script>',
+      nocache: 1
+    }),
+  new OEmbedProvider("boxofficebuz", "video", ["boxofficebuz\\.com\\/embed/.+"], "http://boxofficebuz.com/embed/$1/$2", {templateRegex: [/.*boxofficebuz\.com\/embed\/(\w+)\/([\w*\-*]+)/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider("clipsyndicate", "video", ["clipsyndicate\\.com/video/play/.+", "clipsyndicate\\.com/embed/iframe\?.+"], "http://eplayer.clipsyndicate.com/embed/iframe?pf_id=1&show_title=0&va_id=$1&windows=1", {templateRegex: [/.*www\.clipsyndicate\.com\/video\/play\/(\w+)\/.*/, /.*eplayer\.clipsyndicate\.com\/embed\/iframe\?.*va_id=(\w+).*.*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("coub", "video", ["coub\\.com/.+"], "http://www.coub.com/embed/$1?muted=false&autostart=false&originalSize=false&hideTopBar=false&noSiteButtons=false&startWithHD=false", {templateRegex: [/.*coub\.com\/embed\/(\w+)\?*.*/, /.*coub\.com\/view\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("discoverychannel", "video", ["snagplayer\\.video\\.dp\\.discovery\\.com/.+"], "http://snagplayer.video.dp.discovery.com/$1/snag-it-player.htm?auto=no", {templateRegex: [/.*snagplayer\.video\.dp\.discovery\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider("telly", "video", ["telly\\.com/.+"], "http://www.telly.com/embed.php?guid=$1&autoplay=0", {templateRegex: [/.*telly\.com\/embed\.php\?guid=(\w+).*/, /.*telly\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider("minilogs", "video", ["minilogs\\.com/.+"], "http://www.minilogs.com/e/$1", {templateRegex: [/.*minilogs\.com\/e\/(\w+).*/, /.*minilogs\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("viddy", "video", ["viddy\\.com/.+"], "http://www.viddy.com/embed/video/$1", {templateRegex: [/.*viddy\.com\/embed\/video\/(\.*)/, /.*viddy\.com\/video\/(\.*)/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("worldstarhiphop", "video", ["worldstarhiphop\\.com\/embed/.+"], "http://www.worldstarhiphop.com/embed/$1", {templateRegex: /.*worldstarhiphop\.com\/embed\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("zapiks", "video", ["zapiks\\.fr\/.+"], "http://www.zapiks.fr/index.php?action=playerIframe&media_id=$1&autoStart=fals", {templateRegex: /.*zapiks\.fr\/index.php\?[\w\=\&]*media_id=(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+
+  // Audio
+  new OEmbedProvider("chirbit", "audio", ["chirb\\.it/.+"], "http://chirb.it/wp/$1", {templateRegex: [/.*chirb\.it\/wp\/(\w+).*/, /.*chirb\.it\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("Huffduffer", "rich", ["huffduffer.com/[-.\\w@]+/\\d+"], "http://huffduffer.com/oembed"),
+  new OEmbedProvider("Spotify", "rich", ["open.spotify.com/(track|album|user)/"], "https://embed.spotify.com/oembed/"),
+  new OEmbedProvider("shoudio", "rich", ["shoudio.com/.+", "shoud.io/.+"], "http://shoudio.com/api/oembed"),
+  new OEmbedProvider("rdio.com", "rich", ["rd.io/.+", "rdio.com"], "http://www.rdio.com/api/oembed/"),
+  new OEmbedProvider("Soundcloud", "rich", ["soundcloud.com/.+", "snd.sc/.+"], "//soundcloud.com/oembed", {format: 'js'}),
+
+  // Photo
+  new OEmbedProvider("deviantart", "photo", ["deviantart.com/.+", "fav.me/.+", "deviantart.com/.+"], "//backend.deviantart.com/oembed", {format: 'jsonp'}),
+  new OEmbedProvider("mobypicture", "photo", ["mobypicture.com/user/.+/view/.+", "moby.to/.+"], "http://api.mobypicture.com/oEmbed"),
+  new OEmbedProvider("flickr", "photo", ["flickr\\.com/photos/.+"], "//flickr.com/services/oembed", {callbackparameter: 'jsoncallback'}),
+  new OEmbedProvider("photobucket", "photo", ["photobucket\\.com/(albums|groups)/.+"], "http://photobucket.com/oembed/"),
+  new OEmbedProvider("instagram", "photo", ["instagr\\.?am(\\.com)?/.+"], "//api.instagram.com/oembed"),
+  new OEmbedProvider("SmugMug", "photo", ["smugmug.com/[-.\\w@]+/.+"], "http://api.smugmug.com/services/oembed/"),
+  new OEmbedProvider("dribbble", "photo", ["dribbble.com/shots/.+"], "http://api.dribbble.com/shots/$1?callback=?",
+    {
+      templateRegex: /.*shots\/([\d]+).*/,
+      templateData: function (data) {
+        if (!data.image_teaser_url) {
+          return false;
+        }
+        return  '<img src="' + data.image_teaser_url + '"/>';
+      }
+    }),
+  new OEmbedProvider("chart.ly", "photo", ["chart\\.ly/[a-z0-9]{6,8}"], "http://chart.ly/uploads/large_$1.png",
+    {templateRegex: /.*ly\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
+  new OEmbedProvider("circuitlab", "photo", ["circuitlab.com/circuit/.+"], "https://www.circuitlab.com/circuit/$1/screenshot/540x405/",
+    {templateRegex: /.*circuit\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
+  new OEmbedProvider("img.ly", "photo", ["img\\.ly/.+"], "//img.ly/show/thumb/$1",
+    {templateRegex: /.*ly\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
+  new OEmbedProvider("twitgoo.com", "photo", ["twitgoo\\.com/.+"], "http://twitgoo.com/show/thumb/$1",
+    {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
+  new OEmbedProvider("imgur.com", "photo", ["imgur\\.com/gallery/.+"], "http://imgur.com/$1l.jpg",
+    {templateRegex: /.*gallery\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
+  new OEmbedProvider("achewood", "photo", ["achewood\\.com\\/index.php\\?date=.+"], "http://www.achewood.com/comic.php?date=$1", {templateRegex: /.*achewood\.com\/index.php\?date=(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("fotokritik", "photo", ["fotokritik\\.com/.+"], "http://www.fotokritik.com/embed/$1", {templateRegex: [/.*fotokritik\.com\/embed\/(\w+).*/, /.*fotokritik\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("giflike", "photo", ["giflike\\.com/.+"], "http://www.giflike.com/embed/$1", {templateRegex: [/.*giflike\.com\/embed\/(\w+).*/, /.*giflike\.com\/a\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+
+  // Rich
+  new OEmbedProvider("twitter", "rich", ["twitter.com/.+"], "https://api.twitter.com/1/statuses/oembed.json"),
+  new OEmbedProvider("gmep", "rich", ["gmep.imeducate.com/.*", "gmep.org/.*"], "http://gmep.org/oembed.json"),
+  new OEmbedProvider("urtak", "rich", ["urtak.com/(u|clr)/.+"], "http://oembed.urtak.com/1/oembed"),
+  new OEmbedProvider("cacoo", "rich", ["cacoo.com/.+"], "http://cacoo.com/oembed.json"),
+  new OEmbedProvider("dailymile", "rich", ["dailymile.com/people/.*/entries/.*"], "http://api.dailymile.com/oembed"),
+  new OEmbedProvider("documentcloud", "rich", ["documentcloud.org/documents/.+"], "https://www.documentcloud.org/api/oembed.json"),
+  new OEmbedProvider("popplet", "rich", ["popplet.com/app/.*"], "http://popplet.com/app/Popplet_Alpha.swf?page_id=$1&em=1",
+    {
+      templateRegex: /.*#\/([^\/]+).*/,
+      embedtag: {
+        width: 460,
+        height: 460
+      }
+    }),
+
+  new OEmbedProvider("pearltrees", "rich", ["pearltrees.com/.*"], "http://cdn.pearltrees.com/s/embed/getApp?",
+    {
+      templateRegex: /.*N-f=1_(\d+).*N-p=(\d+).*/,
+      embedtag: {
+        width: 460,
+        height: 460,
+        flashvars: "lang=en_US&amp;embedId=pt-embed-$1-693&amp;treeId=$1&amp;pearlId=$2&amp;treeTitle=Diagrams%2FVisualization&amp;site=www.pearltrees.com%2FF"
+      }
+    }),
+
+  new OEmbedProvider("prezi", "rich", ["prezi.com/.*"], "//prezi.com/bin/preziloader.swf?",
+    {
+      templateRegex: /.*com\/([^\/]+)\/.*/,
+      embedtag: {
+        width: 550,
+        height: 400,
+        flashvars: "prezi_id=$1&amp;lock_to_path=0&amp;color=ffffff&amp;autoplay=no&amp;autohide_ctrls=0"
+      }
+    }),
+
+  new OEmbedProvider("tourwrist", "rich", ["tourwrist.com/tours/.+"], null,
+    {
+      templateRegex: /.*tours.([\d]+).*/,
+      template: function (wm, tourid) {
+        setTimeout(function () {
+          if (loadEmbeds)loadEmbeds();
+        }, 2000);
+        return "<div id='" + tourid + "' class='tourwrist-tour-embed direct'></div> <script type='text/javascript' src='http://tourwrist.com/tour_embed.js'></script>";
+      }
+    }),
+
+  new OEmbedProvider("meetup", "rich", ["meetup\\.(com|ps)/.+"], "http://api.meetup.com/oembed"),
+  new OEmbedProvider("ebay", "rich", ["ebay\\.*"], "http://togo.ebay.com/togo/togo.swf?2008013100",
+    {
+      templateRegex: /.*\/([^\/]+)\/(\d{10,13}).*/,
+      embedtag: {
+        width: 355,
+        height: 300,
+        flashvars: "base=http://togo.ebay.com/togo/&lang=en-us&mode=normal&itemid=$2&query=$1"
+      }
+    }),
+  new OEmbedProvider("wikipedia", "rich", ["wikipedia.org/wiki/.+"], "http://$1.wikipedia.org/w/api.php?action=parse&page=$2&format=json&section=0&callback=?", {
+    templateRegex: /.*\/\/([\w]+).*\/wiki\/([^\/]+).*/,
+    templateData: function (data) {
+      if (!data.parse)
+        return false;
+      var text = data.parse['text']['*'].replace(/href="\/wiki/g, 'href="http://en.wikipedia.org/wiki');
+      return  '<div id="content"><h3><a class="nav-link" href="http://en.wikipedia.org/wiki/' + data.parse['displaytitle'] + '">' + data.parse['displaytitle'] + '</a></h3>' + text + '</div>';
+    }
+  }),
+  new OEmbedProvider("imdb", "rich", ["imdb.com/title/.+"], "http://www.imdbapi.com/?i=$1&callback=?",
+    {
+      templateRegex: /.*\/title\/([^\/]+).*/,
+      templateData: function (data) {
+        if (!data.Title)
+          return false;
+        return  '<div id="content"><h3><a class="nav-link" href="http://imdb.com/title/' + data.imdbID + '/">' + data.Title + '</a> (' + data.Year + ')</h3><p>Rating: ' + data.imdbRating + '<br/>Genre: ' + data.Genre + '<br/>Starring: ' + data.Actors + '</p></div>  <div id="view-photo-caption">' + data.Plot + '</div></div>';
+      }
+    }),
+  new OEmbedProvider("livejournal", "rich", ["livejournal.com/"], "http://ljpic.seacrow.com/json/$2$4?jsonp=?"
+    , {
+      templateRegex: /(http:\/\/(((?!users).)+)\.livejournal\.com|.*users\.livejournal\.com\/([^\/]+)).*/,
+      templateData: function (data) {
+        if (!data.username)
+          return false;
+        return  '<div><img src="' + data.image + '" align="left" style="margin-right: 1em;" /><span class="oembedall-ljuser"><a href="http://' + data.username + '.livejournal.com/profile"><img src="http://www.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" /></a><a href="http://' + data.username + '.livejournal.com/">' + data.username + '</a></span><br />' + data.name + '</div>';
+      }
+    }),
+  new OEmbedProvider("circuitbee", "rich", ["circuitbee\\.com/circuit/view/.+"], "http://c.circuitbee.com/build/r/schematic-embed.html?id=$1",
+    {
+      templateRegex: /.*circuit\/view\/(\d+).*/,
+      embedtag: {
+        tag: 'iframe',
+        width: '500',
+        height: '350'
+      }
+    }),
+
+  new OEmbedProvider("googlecalendar", "rich", ["www.google.com/calendar/embed?.+"], "$1",
+    {templateRegex: /(.*)/, embedtag: {tag: 'iframe', width: '800', height: '600' }}),
+  new OEmbedProvider("jsfiddle", "rich", ["jsfiddle.net/[^/]+/?"], "http://jsfiddle.net/$1/embedded/result,js,resources,html,css/?",
+    {templateRegex: /.*net\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: '300' }}),
+  new OEmbedProvider("jsbin", "rich", ["jsbin.com/.+"], "http://jsbin.com/$1/?",
+    {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: '300' }}),
+  new OEmbedProvider("jotform", "rich", ["form.jotform.co/form/.+"], "$1?",
+    {templateRegex: /(.*)/, embedtag: {tag: 'iframe', width: '100%', height: '507' }}),
+  new OEmbedProvider("reelapp", "rich", ["reelapp\\.com/.+"], "http://www.reelapp.com/$1/embed",
+    {templateRegex: /.*com\/(\S{6}).*/, embedtag: {tag: 'iframe', width: '400', height: '338'}}),
+  new OEmbedProvider("linkedin", "rich", ["linkedin.com/pub/.+"], "https://www.linkedin.com/cws/member/public_profile?public_profile_url=$1&format=inline&isFramed=true",
+    {templateRegex: /(.*)/, embedtag: {tag: 'iframe', width: '368px', height: 'auto'}}),
+  new OEmbedProvider("timetoast", "rich", ["timetoast.com/timelines/[0-9]+"], "http://www.timetoast.com/flash/TimelineViewer.swf?passedTimelines=$1",
+    {templateRegex: /.*timelines\/([0-9]*)/, embedtag: { width: 550, height: 400}, nocache: 1}),
+  new OEmbedProvider("pastebin", "rich", ["pastebin\\.com/[\\S]{8}"], "http://pastebin.com/embed_iframe.php?i=$1",
+    {templateRegex: /.*\/(\S{8}).*/, embedtag: {tag: 'iframe', width: '100%', height: 'auto'}}),
+  new OEmbedProvider("mixlr", "rich", ["mixlr.com/.+"], "http://mixlr.com/embed/$1?autoplay=ae",
+    {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: 'auto' }}),
+  // GitHub is causing issues.
+  // new OEmbedProvider("github", "rich", ["gist.github.com/.+"], "https://github.com/api/oembed"),
+  // new OEmbedProvider("github", "rich", ["github.com/[-.\\w@]+/[-.\\w@]+"], "https://api.github.com/repos/$1/$2?callback=?"
+  //   , {templateRegex: /.*\/([^\/]+)\/([^\/]+).*/,
+  //     templateData: function (data) {
+  //       if (!data.data.html_url)return false;
+  //       return  '<div class="oembedall-githubrepos"><ul class="oembedall-repo-stats"><li>' + data.data.language + '</li><li class="oembedall-watchers"><a title="Watchers" href="' + data.data.html_url + '/watchers">&#x25c9; ' + data.data.watchers + '</a></li>'
+  //         + '<li class="oembedall-forks"><a title="Forks" href="' + data.data.html_url + '/network">&#x0265; ' + data.data.forks + '</a></li></ul><h3><a href="' + data.data.html_url + '">' + data.data.name + '</a></h3><div class="oembedall-body"><p class="oembedall-description">' + data.data.description + '</p>'
+  //         + '<p class="oembedall-updated-at">Last updated: ' + data.data.pushed_at + '</p></div></div>';
+  //     }
+  //   }),
+  new OEmbedProvider("stackoverflow", "rich", ["stackoverflow.com/questions/[\\d]+"], "http://api.stackoverflow.com/1.1/questions/$1?body=true&jsonp=?"
+    , {templateRegex: /.*questions\/([\d]+).*/,
+      templateData: function (data) {
+        if (!data.questions)
+          return false;
+        var q = data.questions[0];
+        var body = $(q.body).text();
+        var out = '<div class="oembedall-stoqembed"><div class="oembedall-statscontainer"><div class="oembedall-statsarrow"></div><div class="oembedall-stats"><div class="oembedall-vote"><div class="oembedall-votes">'
+          + '<span class="oembedall-vote-count-post"><strong>' + (q.up_vote_count - q.down_vote_count) + '</strong></span><div class="oembedall-viewcount">vote(s)</div></div>'
+          + '</div><div class="oembedall-status"><strong>' + q.answer_count + '</strong>answer</div></div><div class="oembedall-views">' + q.view_count + ' view(s)</div></div>'
+          + '<div class="oembedall-summary"><h3><a class="oembedall-question-hyperlink" href="http://stackoverflow.com/questions/' + q.question_id + '/">' + q.title + '</a></h3>'
+          + '<div class="oembedall-excerpt">' + body.substring(0, 100) + '...</div><div class="oembedall-tags">';
+        for (i in q.tags) {
+          out += '<a title="" class="oembedall-post-tag" href="http://stackoverflow.com/questions/tagged/' + q.tags[i] + '">' + q.tags[i] + '</a>';
+        }
+
+        out += '</div><div class="oembedall-fr"><div class="oembedall-user-info"><div class="oembedall-user-gravatar32"><a href="http://stackoverflow.com/users/' + q.owner.user_id + '/' + q.owner.display_name + '">'
+          + '<img width="32" height="32" alt="" src="http://www.gravatar.com/avatar/' + q.owner.email_hash + '?s=32&amp;d=identicon&amp;r=PG"></a></div><div class="oembedall-user-details">'
+          + '<a href="http://stackoverflow.com/users/' + q.owner.user_id + '/' + q.owner.display_name + '">' + q.owner.display_name + '</a><br><span title="reputation score" class="oembedall-reputation-score">'
+          + q.owner.reputation + '</span></div></div></div></div></div>';
+        return out;
+      }
+    }),
+  new OEmbedProvider("wordpress", "rich", ["wordpress\\.com/.+", "blogs\\.cnn\\.com/.+", "techcrunch\\.com/.+", "wp\\.me/.+"], "http://public-api.wordpress.com/oembed/1.0/?for=jquery-oembed-all"),
+  new OEmbedProvider("screenr", "rich", ["screenr\.com"], "http://www.screenr.com/embed/$1",
+    {templateRegex: /.*\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '650', height: 396}}) ,
+  new OEmbedProvider("gigpans", "rich", ["gigapan\\.org/[-.\\w@]+/\\d+"], "http://gigapan.org/gigapans/$1/options/nosnapshots/iframe/flash.html",
+    {templateRegex: /.*\/(\d+)\/?.*/, embedtag: {tag: 'iframe', width: '100%', height: 400 }}),
+  new OEmbedProvider("scribd", "rich", ["scribd\\.com/.+"], "http://www.scribd.com/embeds/$1/content?start_page=1&view_mode=list",
+    {templateRegex: /.*doc\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: 600}}),
+  new OEmbedProvider("kickstarter", "rich", ["kickstarter\\.com/projects/.+"], "$1/widget/card.html",
+    {templateRegex: /([^\?]+).*/, embedtag: {tag: 'iframe', width: '220', height: 380}}),
+  new OEmbedProvider("slideshare", "rich", ["slideshare\.net"], "//www.slideshare.net/api/oembed/2", {format: 'jsonp'}),
+  new OEmbedProvider("roomsharejp", "rich", ["roomshare\\.jp/(en/)?post/.*"], "http://roomshare.jp/oembed.json"),
+  new OEmbedProvider("coveritlive", "rich", ["coveritlive.com/"], null, {
+    templateRegex: /(.*)/,
+    template: '<iframe src="$1" allowtransparency="true" scrolling="no" width="615px" frameborder="0" height="625px"></iframe>'}),
+  new OEmbedProvider("polldaddy", "rich", ["polldaddy.com/"], null, {
+    templateRegex: /(?:https?:\/\/w?w?w?.?polldaddy.com\/poll\/)([0-9]*)\//,
+    template: '<script async type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/p/$1.js"></script>',
+    nocache: 1
+  }),
+  new OEmbedProvider("360io", "rich", ["360\\.io/.+"], "http://360.io/$1", {templateRegex: /.*360\.io\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("bubbli", "rich", ["on\\.bubb\\.li/.+"], "http://on.bubb.li/$1", {templateRegex: /.*on\.bubb\.li\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360}, nocache: 1 }),
+  new OEmbedProvider("cloudup", "rich", ["cloudup\\.com/.+"], "http://cloudup.com/$1?chromeless", {templateRegex: [/.*cloudup\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider("codepen", "rich", ["codepen.io/.+"], "http://codepen.io/$1/embed/$2", {templateRegex: [/.*io\/(\w+)\/pen\/(\w+).*/, /.*io\/(\w+)\/full\/(\w+).*/], embedtag: {tag: 'iframe', width: '100%', height: '300'}, nocache: 1 }),
+  new OEmbedProvider("googleviews", "rich", ["(.*maps\\.google\\.com\\/maps\\?).+(output=svembed).+(cbp=(.*)).*"], "https://maps.google.com/maps?layer=c&panoid=$3&ie=UTF8&source=embed&output=svembed&cbp=$5", {templateRegex: /(.*maps\.google\.com\/maps\?).+(panoid=(\w+)&).*(cbp=(.*)).*/, embedtag: {tag: 'iframe', width: 480, height: 360}, nocache: 1 }),
+  new OEmbedProvider("googlemaps", "rich", ["google\\.com\/maps\/place/.+"], "http://maps.google.com/maps?t=m&q=$1&output=embed", {templateRegex: /.*google\.com\/maps\/place\/([\w\+]*)\/.*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("imajize", "rich", ["embed\\.imajize\\.com/.+"], "http://embed.imajize.com/$1", {templateRegex: /.*embed\.imajize\.com\/(.*)/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("mapjam", "rich", ["mapjam\\.com/.+"], "http://www.mapjam.com/$1", {templateRegex: /.*mapjam\.com\/(.*)/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("polar", "rich", ["polarb\\.com/.+"], "http://assets-polarb-com.a.ssl.fastly.net/api/v4/publishers/unknown/embedded_polls/iframe?poll_id=$1", {templateRegex: /.*polarb\.com\/polls\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider("ponga", "rich", ["ponga\\.com/.+"], "https://www.ponga.com/embedded?id=$1", {templateRegex: [/.*ponga\.com\/embedded\?id=(\w+).*/, /.*ponga\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1})
+
+];
+
+r.confirm("script","oembed_providers");

--- a/scripts/oembed_providers.js
+++ b/scripts/oembed_providers.js
@@ -1,4 +1,25 @@
-// This is a subset of the providers list from https://github.com/nfl/jquery-oembed-all/blob/master/jquery.oembed.js
+// This wouldn't be possible without the providers data from https://github.com/nfl/jquery-oembed-all/blob/master/jquery.oembed.js
+function OEmbedProvider(name, type, urlschemesarray, apiendpoint, extraSettings) {
+  this.name = name;
+  this.type = type; // "photo", "video", "link", "rich", null
+  this.urlschemes = urlschemesarray;
+  for (var i in this.urlschemes) {
+    this.urlschemes[i] = new RegExp(this.urlschemes[i], "i");
+  }
+  this.apiendpoint = apiendpoint;
+  this.maxWidth = 500;
+  this.maxHeight = 400;
+  extraSettings = extraSettings || {};
+
+  for (var property in extraSettings) {
+      this[property] = extraSettings[property];
+  }
+
+  this.format = this.format || "json";
+  this.callbackparameter = this.callbackparameter || "callback";
+  this.embedtag = this.embedtag || {tag: ""};
+}
+
 r.oembed_providers = [
 
   // Video
@@ -214,7 +235,7 @@ r.oembed_providers = [
     {templateRegex: /.*\/(\S{8}).*/, embedtag: {tag: 'iframe', width: '100%', height: 'auto'}}),
   new OEmbedProvider("mixlr", "rich", ["mixlr.com/.+"], "http://mixlr.com/embed/$1?autoplay=ae",
     {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: 'auto' }}),
-  // GitHub is causing issues.
+  // GitHub is causing issues (rate limiting, "invalid" responses, ...)
   // new OEmbedProvider("github", "rich", ["gist.github.com/.+"], "https://github.com/api/oembed"),
   // new OEmbedProvider("github", "rich", ["github.com/[-.\\w@]+/[-.\\w@]+"], "https://api.github.com/repos/$1/$2?callback=?"
   //   , {templateRegex: /.*\/([^\/]+)\/([^\/]+).*/,

--- a/scripts/oembed_providers.js
+++ b/scripts/oembed_providers.js
@@ -20,7 +20,7 @@ function OEmbedProvider(name, type, urlschemesarray, apiendpoint, extraSettings)
   this.embedtag = this.embedtag || {tag: ""};
 }
 
-r.oembed_providers = [
+OEmbed.providers = [
 
   // Video
   new OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], '//www.youtube.com/embed/$1?wmode=transparent', {

--- a/scripts/oembed_providers.js
+++ b/scripts/oembed_providers.js
@@ -1,18 +1,14 @@
 // This wouldn't be possible without the providers data from https://github.com/nfl/jquery-oembed-all/blob/master/jquery.oembed.js
-function OEmbedProvider(name, type, urlschemesarray, apiendpoint, extraSettings) {
-  this.name = name;
-  this.type = type; // "photo", "video", "link", "rich", null
-  this.urlschemes = urlschemesarray;
+function OEmbedProvider(urlschemes, api, data) {
+  this.urlschemes = urlschemes;
   for (var i in this.urlschemes) {
     this.urlschemes[i] = new RegExp(this.urlschemes[i], "i");
   }
-  this.apiendpoint = apiendpoint;
-  this.maxWidth = 500;
-  this.maxHeight = 400;
-  extraSettings = extraSettings || {};
+  this.api = api;
 
-  for (var property in extraSettings) {
-      this[property] = extraSettings[property];
+  data = data || {};
+  for (var property in data) {
+      this[property] = data[property];
   }
 
   this.format = this.format || "json";
@@ -23,83 +19,65 @@ function OEmbedProvider(name, type, urlschemesarray, apiendpoint, extraSettings)
 OEmbed.providers = [
 
   // Video
-  new OEmbedProvider("youtube", "video", ["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], '//www.youtube.com/embed/$1?wmode=transparent', {
+  new OEmbedProvider(["youtube\\.com/watch.+v=[\\w-]+&?", "youtu\\.be/[\\w-]+", "youtube.com/embed"], '//www.youtube.com/embed/$1?wmode=transparent', {
     templateRegex: /.*(?:v\=|be\/|embed\/)([\w\-]+)&?.*/, embedtag: {tag: 'iframe', width: '425', height: '349'}
   }),
 
-  new OEmbedProvider("xtranormal", "video", ["xtranormal\\.com/watch/.+"], "http://www.xtranormal.com/xtraplayr/$1/$2", {
+  new OEmbedProvider(["xtranormal\\.com/watch/.+"], "https://www.xtranormal.com/xtraplayr/$1/$2", {
     templateRegex: /.*com\/watch\/([\w\-]+)\/([\w\-]+).*/, embedtag: {tag: 'iframe', width: '320', height: '269'}}),
-  new OEmbedProvider("scivee", "video", ["scivee.tv/node/.+"], "http://www.scivee.tv/flash/embedCast.swf?", {
-    templateRegex: /.*tv\/node\/(.+)/, embedtag: {width: '480', height: '400', flashvars: "id=$1&type=3"}}),
-  new OEmbedProvider("veoh", "video", ["veoh.com/watch/.+"], "http://www.veoh.com/swf/webplayer/WebPlayer.swf?version=AFrontend.5.7.0.1337&permalinkId=$1&player=videodetailsembedded&videoAutoPlay=0&id=anonymous", {
-    templateRegex: /.*watch\/([^\?]+).*/, embedtag: {width: '410', height: '341'}}),
-  new OEmbedProvider("gametrailers", "video", ["gametrailers\\.com/video/.+"], "http://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$2", {
+  new OEmbedProvider(["gametrailers\\.com/video/.+"], "https://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$2", {
     templateRegex: /.*com\/video\/([\w\-]+)\/([\w\-]+).*/, embedtag: {width: '512', height: '288' }}),
-  new OEmbedProvider("funnyordie", "video", ["funnyordie\\.com/videos/.+"], "http://player.ordienetworks.com/flash/fodplayer.swf?", {
-    templateRegex: /.*videos\/([^\/]+)\/([^\/]+)?/, embedtag: {width: 512, height: 328, flashvars: "key=$1"}}),
-  new OEmbedProvider("collegehumour", "video", ["collegehumor\\.com/video/.+"], "http://www.collegehumor.com/moogaloop/moogaloop.swf?clip_id=$1&use_node_id=true&fullscreen=1",
-    {templateRegex: /.*video\/([^\/]+).*/, embedtag: {width: 600, height: 338}}),
-  new OEmbedProvider("metacafe", "video", ["metacafe\\.com/watch/.+"], "http://www.metacafe.com/fplayer/$1/$2.swf",
-    {templateRegex: /.*watch\/(\d+)\/(\w+)\/.*/, embedtag: {width: 400, height: 345}}),
-  new OEmbedProvider("bambuser", "video", ["bambuser\\.com\/channel\/.*\/broadcast\/.*"], "http://static.bambuser.com/r/player.swf?vid=$1",
-    {templateRegex: /.*bambuser\.com\/channel\/.*\/broadcast\/(\w+).*/, embedtag: {width: 512, height: 339 }}),
-  new OEmbedProvider("twitvid", "video", ["twitvid\\.com/.+"], "http://www.twitvid.com/embed.php?guid=$1&autoplay=0",
+  new OEmbedProvider(["twitvid\\.com/.+"], "https://www.twitvid.com/embed.php?guid=$1&autoplay=0",
     {templateRegex: /.*twitvid\.com\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }}),
-  new OEmbedProvider("aniboom", "video", ["aniboom\\.com/animation-video/.+"], "http://api.aniboom.com/e/$1",
+  new OEmbedProvider(["aniboom\\.com/animation-video/.+"], "https://api.aniboom.com/e/$1",
     {templateRegex: /.*animation-video\/(\d+).*/, embedtag: {width: 594, height: 334}}),
-  new OEmbedProvider("vzaar", "video", ["vzaar\\.com/videos/.+", "vzaar.tv/.+"], "http://view.vzaar.com/$1/player?",
+  new OEmbedProvider(["vzaar\\.com/videos/.+", "vzaar.tv/.+"], "https://view.vzaar.com/$1/player?",
     {templateRegex: /.*\/(\d+).*/, embedtag: {tag: 'iframe', width: 576, height: 324 }}),
-  new OEmbedProvider("snotr", "video", ["snotr\\.com/video/.+"], "http://www.snotr.com/embed/$1",
+  new OEmbedProvider(["snotr\\.com/video/.+"], "https://www.snotr.com/embed/$1",
     {templateRegex: /.*\/(\d+).*/, embedtag: {tag: 'iframe', width: 400, height: 330}, nocache: 1 }),
-  new OEmbedProvider("youku", "video", ["v.youku.com/v_show/id_.+"], "http://player.youku.com/player.php/sid/$1/v.swf",
-    {templateRegex: /.*id_(.+)\.html.*/, embedtag: {width: 480, height: 400}, nocache: 1 }),
-  new OEmbedProvider("tudou", "video", ["tudou.com/programs/view/.+\/"], "http://www.tudou.com/v/$1/v.swf",
-    {templateRegex: /.*view\/(.+)\//, embedtag: {width: 480, height: 400}, nocache: 1 }),
-  new OEmbedProvider("embedr", "video", ["embedr\\.com/playlist/.+"], "http://embedr.com/swf/slider/$1/425/520/default/false/std?",
-    {templateRegex: /.*playlist\/([^\/]+).*/, embedtag: {width: 425, height: 520}}),
-  new OEmbedProvider("blip", "video", ["blip\\.tv/.+"], "//blip.tv/oembed/"),
-  new OEmbedProvider("animoto", "video", ["animoto.com/play/.+"], "http://animoto.com/services/oembed"),
-  new OEmbedProvider("hulu", "video", ["hulu\\.com/watch/.*"], "//www.hulu.com/api/oembed.json"),
-  new OEmbedProvider("vimeo", "video", ["www\.vimeo\.com\/groups\/.*\/videos\/.*", "www\.vimeo\.com\/.*", "vimeo\.com\/groups\/.*\/videos\/.*", "vimeo\.com\/.*"], "//vimeo.com/api/oembed.json"),
-  new OEmbedProvider("dailymotion", "video", ["dailymotion\\.com/.+"], '//www.dailymotion.com/services/oembed'),
-  new OEmbedProvider("revision3", "video", ["revision3\\.com"], "http://revision3.com/api/oembed/"),
-  new OEmbedProvider("clikthrough", "video", ["clikthrough\\.com/theater/video/\\d+"], "http://clikthrough.com/services/oembed"),
-  new OEmbedProvider("Kinomap", "video", ["kinomap\\.com/.+"], "http://www.kinomap.com/oembed"),
-  new OEmbedProvider("VHX", "video", ["vhx.tv/.+"], "http://vhx.tv/services/oembed.json"),
-  new OEmbedProvider("bambuser", "video", ["bambuser.com/.+"], "http://api.bambuser.com/oembed/iframe.json"),
-  new OEmbedProvider("vine", "video", ["vine.co/v/.*"], null,
+  new OEmbedProvider(["blip\\.tv/.+"], "//blip.tv/oembed/"),
+  new OEmbedProvider(["animoto.com/play/.+"], "https://animoto.com/services/oembed"),
+  new OEmbedProvider(["hulu\\.com/watch/.*"], "//www.hulu.com/api/oembed.json"),
+  new OEmbedProvider(["www\.vimeo\.com\/groups\/.*\/videos\/.*", "www\.vimeo\.com\/.*", "vimeo\.com\/groups\/.*\/videos\/.*", "vimeo\.com\/.*"], "//vimeo.com/api/oembed.json"),
+  new OEmbedProvider(["dailymotion\\.com/.+"], '//www.dailymotion.com/services/oembed'),
+  new OEmbedProvider(["revision3\\.com"], "https://revision3.com/api/oembed/"),
+  new OEmbedProvider(["clikthrough\\.com/theater/video/\\d+"], "https://clikthrough.com/services/oembed"),
+  new OEmbedProvider(["kinomap\\.com/.+"], "https://www.kinomap.com/oembed"),
+  new OEmbedProvider(["vhx.tv/.+"], "https://vhx.tv/services/oembed.json"),
+  new OEmbedProvider(["bambuser.com/.+"], "https://api.bambuser.com/oembed/iframe.json"),
+  new OEmbedProvider(["vine.co/v/.*"], null,
     {
       templateRegex: /https?:\/\/w?w?w?.?vine\.co\/v\/([a-zA-Z0-9]*).*/,
       template: '<iframe src="https://vine.co/v/$1/embed/postcard" width="600" height="600" allowfullscreen="true" allowscriptaccess="always" scrolling="no" frameborder="0"></iframe>' +
         '<script async src="//platform.vine.co/static/scripts/embed.js" charset="utf-8"></script>',
       nocache: 1
     }),
-  new OEmbedProvider("boxofficebuz", "video", ["boxofficebuz\\.com\\/embed/.+"], "http://boxofficebuz.com/embed/$1/$2", {templateRegex: [/.*boxofficebuz\.com\/embed\/(\w+)\/([\w*\-*]+)/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
-  new OEmbedProvider("clipsyndicate", "video", ["clipsyndicate\\.com/video/play/.+", "clipsyndicate\\.com/embed/iframe\?.+"], "http://eplayer.clipsyndicate.com/embed/iframe?pf_id=1&show_title=0&va_id=$1&windows=1", {templateRegex: [/.*www\.clipsyndicate\.com\/video\/play\/(\w+)\/.*/, /.*eplayer\.clipsyndicate\.com\/embed\/iframe\?.*va_id=(\w+).*.*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("coub", "video", ["coub\\.com/.+"], "http://www.coub.com/embed/$1?muted=false&autostart=false&originalSize=false&hideTopBar=false&noSiteButtons=false&startWithHD=false", {templateRegex: [/.*coub\.com\/embed\/(\w+)\?*.*/, /.*coub\.com\/view\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("discoverychannel", "video", ["snagplayer\\.video\\.dp\\.discovery\\.com/.+"], "http://snagplayer.video.dp.discovery.com/$1/snag-it-player.htm?auto=no", {templateRegex: [/.*snagplayer\.video\.dp\.discovery\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
-  new OEmbedProvider("telly", "video", ["telly\\.com/.+"], "http://www.telly.com/embed.php?guid=$1&autoplay=0", {templateRegex: [/.*telly\.com\/embed\.php\?guid=(\w+).*/, /.*telly\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
-  new OEmbedProvider("minilogs", "video", ["minilogs\\.com/.+"], "http://www.minilogs.com/e/$1", {templateRegex: [/.*minilogs\.com\/e\/(\w+).*/, /.*minilogs\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("viddy", "video", ["viddy\\.com/.+"], "http://www.viddy.com/embed/video/$1", {templateRegex: [/.*viddy\.com\/embed\/video\/(\.*)/, /.*viddy\.com\/video\/(\.*)/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("worldstarhiphop", "video", ["worldstarhiphop\\.com\/embed/.+"], "http://www.worldstarhiphop.com/embed/$1", {templateRegex: /.*worldstarhiphop\.com\/embed\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("zapiks", "video", ["zapiks\\.fr\/.+"], "http://www.zapiks.fr/index.php?action=playerIframe&media_id=$1&autoStart=fals", {templateRegex: /.*zapiks\.fr\/index.php\?[\w\=\&]*media_id=(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["boxofficebuz\\.com\\/embed/.+"], "https://boxofficebuz.com/embed/$1/$2", {templateRegex: [/.*boxofficebuz\.com\/embed\/(\w+)\/([\w*\-*]+)/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider(["clipsyndicate\\.com/video/play/.+", "clipsyndicate\\.com/embed/iframe\?.+"], "https://eplayer.clipsyndicate.com/embed/iframe?pf_id=1&show_title=0&va_id=$1&windows=1", {templateRegex: [/.*www\.clipsyndicate\.com\/video\/play\/(\w+)\/.*/, /.*eplayer\.clipsyndicate\.com\/embed\/iframe\?.*va_id=(\w+).*.*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["coub\\.com/.+"], "https://www.coub.com/embed/$1?muted=false&autostart=false&originalSize=false&hideTopBar=false&noSiteButtons=false&startWithHD=false", {templateRegex: [/.*coub\.com\/embed\/(\w+)\?*.*/, /.*coub\.com\/view\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["snagplayer\\.video\\.dp\\.discovery\\.com/.+"], "https://snagplayer.video.dp.discovery.com/$1/snag-it-player.htm?auto=no", {templateRegex: [/.*snagplayer\.video\.dp\.discovery\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider(["telly\\.com/.+"], "https://www.telly.com/embed.php?guid=$1&autoplay=0", {templateRegex: [/.*telly\.com\/embed\.php\?guid=(\w+).*/, /.*telly\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider(["minilogs\\.com/.+"], "https://www.minilogs.com/e/$1", {templateRegex: [/.*minilogs\.com\/e\/(\w+).*/, /.*minilogs\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["viddy\\.com/.+"], "https://www.viddy.com/embed/video/$1", {templateRegex: [/.*viddy\.com\/embed\/video\/(\.*)/, /.*viddy\.com\/video\/(\.*)/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["worldstarhiphop\\.com\/embed/.+"], "https://www.worldstarhiphop.com/embed/$1", {templateRegex: /.*worldstarhiphop\.com\/embed\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["zapiks\\.fr\/.+"], "https://www.zapiks.fr/index.php?action=playerIframe&media_id=$1&autoStart=fals", {templateRegex: /.*zapiks\.fr\/index.php\?[\w\=\&]*media_id=(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
 
   // Audio
-  new OEmbedProvider("chirbit", "audio", ["chirb\\.it/.+"], "http://chirb.it/wp/$1", {templateRegex: [/.*chirb\.it\/wp\/(\w+).*/, /.*chirb\.it\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("Huffduffer", "rich", ["huffduffer.com/[-.\\w@]+/\\d+"], "http://huffduffer.com/oembed"),
-  new OEmbedProvider("Spotify", "rich", ["open.spotify.com/(track|album|user)/"], "https://embed.spotify.com/oembed/"),
-  new OEmbedProvider("shoudio", "rich", ["shoudio.com/.+", "shoud.io/.+"], "http://shoudio.com/api/oembed"),
-  new OEmbedProvider("rdio.com", "rich", ["rd.io/.+", "rdio.com"], "http://www.rdio.com/api/oembed/"),
-  new OEmbedProvider("Soundcloud", "rich", ["soundcloud.com/.+", "snd.sc/.+"], "//soundcloud.com/oembed", {format: 'js'}),
+  new OEmbedProvider(["chirb\\.it/.+"], "https://chirb.it/wp/$1", {templateRegex: [/.*chirb\.it\/wp\/(\w+).*/, /.*chirb\.it\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["huffduffer.com/[-.\\w@]+/\\d+"], "https://huffduffer.com/oembed"),
+  new OEmbedProvider(["open.spotify.com/(track|album|user)/"], "https://embed.spotify.com/oembed/"),
+  new OEmbedProvider(["shoudio.com/.+", "shoud.io/.+"], "https://shoudio.com/api/oembed"),
+  new OEmbedProvider(["rd.io/.+", "rdio.com"], "https://www.rdio.com/api/oembed/"),
+  new OEmbedProvider(["soundcloud.com/.+", "snd.sc/.+"], "//soundcloud.com/oembed", {format: 'js'}),
 
   // Photo
-  new OEmbedProvider("deviantart", "photo", ["deviantart.com/.+", "fav.me/.+", "deviantart.com/.+"], "//backend.deviantart.com/oembed", {format: 'jsonp'}),
-  new OEmbedProvider("mobypicture", "photo", ["mobypicture.com/user/.+/view/.+", "moby.to/.+"], "http://api.mobypicture.com/oEmbed"),
-  new OEmbedProvider("flickr", "photo", ["flickr\\.com/photos/.+"], "//flickr.com/services/oembed", {callbackparameter: 'jsoncallback'}),
-  new OEmbedProvider("photobucket", "photo", ["photobucket\\.com/(albums|groups)/.+"], "http://photobucket.com/oembed/"),
-  new OEmbedProvider("instagram", "photo", ["instagr\\.?am(\\.com)?/.+"], "//api.instagram.com/oembed"),
-  new OEmbedProvider("SmugMug", "photo", ["smugmug.com/[-.\\w@]+/.+"], "http://api.smugmug.com/services/oembed/"),
-  new OEmbedProvider("dribbble", "photo", ["dribbble.com/shots/.+"], "http://api.dribbble.com/shots/$1?callback=?",
+  new OEmbedProvider(["deviantart.com/.+", "fav.me/.+", "deviantart.com/.+"], "//backend.deviantart.com/oembed", {format: 'jsonp'}),
+  new OEmbedProvider(["mobypicture.com/user/.+/view/.+", "moby.to/.+"], "https://api.mobypicture.com/oEmbed"),
+  new OEmbedProvider(["flickr\\.com/photos/.+"], "//flickr.com/services/oembed", {callbackparameter: 'jsoncallback'}),
+  new OEmbedProvider(["photobucket\\.com/(albums|groups)/.+"], "https://photobucket.com/oembed/"),
+  new OEmbedProvider(["instagr\\.?am(\\.com)?/.+"], "//api.instagram.com/oembed"),
+  new OEmbedProvider(["smugmug.com/[-.\\w@]+/.+"], "https://api.smugmug.com/services/oembed/"),
+  new OEmbedProvider(["dribbble.com/shots/.+"], "https://api.dribbble.com/shots/$1",
     {
       templateRegex: /.*shots\/([\d]+).*/,
       templateData: function (data) {
@@ -109,135 +87,43 @@ OEmbed.providers = [
         return  '<img src="' + data.image_teaser_url + '"/>';
       }
     }),
-  new OEmbedProvider("chart.ly", "photo", ["chart\\.ly/[a-z0-9]{6,8}"], "http://chart.ly/uploads/large_$1.png",
+  new OEmbedProvider(["chart\\.ly/[a-z0-9]{6,8}"], "https://chart.ly/uploads/large_$1.png",
     {templateRegex: /.*ly\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
-  new OEmbedProvider("circuitlab", "photo", ["circuitlab.com/circuit/.+"], "https://www.circuitlab.com/circuit/$1/screenshot/540x405/",
+  new OEmbedProvider(["circuitlab.com/circuit/.+"], "https://www.circuitlab.com/circuit/$1/screenshot/540x405/",
     {templateRegex: /.*circuit\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
-  new OEmbedProvider("img.ly", "photo", ["img\\.ly/.+"], "//img.ly/show/thumb/$1",
+  new OEmbedProvider(["img\\.ly/.+"], "//img.ly/show/thumb/$1",
     {templateRegex: /.*ly\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
-  new OEmbedProvider("twitgoo.com", "photo", ["twitgoo\\.com/.+"], "http://twitgoo.com/show/thumb/$1",
+  new OEmbedProvider(["twitgoo\\.com/.+"], "https://twitgoo.com/show/thumb/$1",
     {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
-  new OEmbedProvider("imgur.com", "photo", ["imgur\\.com/gallery/.+"], "http://imgur.com/$1l.jpg",
-    {templateRegex: /.*gallery\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
-  new OEmbedProvider("achewood", "photo", ["achewood\\.com\\/index.php\\?date=.+"], "http://www.achewood.com/comic.php?date=$1", {templateRegex: /.*achewood\.com\/index.php\?date=(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("fotokritik", "photo", ["fotokritik\\.com/.+"], "http://www.fotokritik.com/embed/$1", {templateRegex: [/.*fotokritik\.com\/embed\/(\w+).*/, /.*fotokritik\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("giflike", "photo", ["giflike\\.com/.+"], "http://www.giflike.com/embed/$1", {templateRegex: [/.*giflike\.com\/embed\/(\w+).*/, /.*giflike\.com\/a\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider([".imgur\\.com/(?!gallery/)(.+)"], "https://i.imgur.com/$1",
+    {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'img'}, nocache: 1}),
+  new OEmbedProvider(["achewood\\.com\\/index.php\\?date=.+"], "https://www.achewood.com/comic.php?date=$1", {templateRegex: /.*achewood\.com\/index.php\?date=(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["fotokritik\\.com/.+"], "https://www.fotokritik.com/embed/$1", {templateRegex: [/.*fotokritik\.com\/embed\/(\w+).*/, /.*fotokritik\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["giflike\\.com/.+"], "https://www.giflike.com/embed/$1", {templateRegex: [/.*giflike\.com\/embed\/(\w+).*/, /.*giflike\.com\/a\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
 
   // Rich
-  new OEmbedProvider("twitter", "rich", ["twitter.com/.+"], "https://api.twitter.com/1/statuses/oembed.json"),
-  new OEmbedProvider("gmep", "rich", ["gmep.imeducate.com/.*", "gmep.org/.*"], "http://gmep.org/oembed.json"),
-  new OEmbedProvider("urtak", "rich", ["urtak.com/(u|clr)/.+"], "http://oembed.urtak.com/1/oembed"),
-  new OEmbedProvider("cacoo", "rich", ["cacoo.com/.+"], "http://cacoo.com/oembed.json"),
-  new OEmbedProvider("dailymile", "rich", ["dailymile.com/people/.*/entries/.*"], "http://api.dailymile.com/oembed"),
-  new OEmbedProvider("documentcloud", "rich", ["documentcloud.org/documents/.+"], "https://www.documentcloud.org/api/oembed.json"),
-  new OEmbedProvider("popplet", "rich", ["popplet.com/app/.*"], "http://popplet.com/app/Popplet_Alpha.swf?page_id=$1&em=1",
-    {
-      templateRegex: /.*#\/([^\/]+).*/,
-      embedtag: {
-        width: 460,
-        height: 460
-      }
-    }),
+  new OEmbedProvider(["twitter.com/.+"], "https://api.twitter.com/1/statuses/oembed.json"),
+  new OEmbedProvider(["meetup\\.(com|ps)/.+"], "https://api.meetup.com/oembed"),
 
-  new OEmbedProvider("pearltrees", "rich", ["pearltrees.com/.*"], "http://cdn.pearltrees.com/s/embed/getApp?",
-    {
-      templateRegex: /.*N-f=1_(\d+).*N-p=(\d+).*/,
-      embedtag: {
-        width: 460,
-        height: 460,
-        flashvars: "lang=en_US&amp;embedId=pt-embed-$1-693&amp;treeId=$1&amp;pearlId=$2&amp;treeTitle=Diagrams%2FVisualization&amp;site=www.pearltrees.com%2FF"
-      }
-    }),
-
-  new OEmbedProvider("prezi", "rich", ["prezi.com/.*"], "//prezi.com/bin/preziloader.swf?",
-    {
-      templateRegex: /.*com\/([^\/]+)\/.*/,
-      embedtag: {
-        width: 550,
-        height: 400,
-        flashvars: "prezi_id=$1&amp;lock_to_path=0&amp;color=ffffff&amp;autoplay=no&amp;autohide_ctrls=0"
-      }
-    }),
-
-  new OEmbedProvider("tourwrist", "rich", ["tourwrist.com/tours/.+"], null,
-    {
-      templateRegex: /.*tours.([\d]+).*/,
-      template: function (wm, tourid) {
-        setTimeout(function () {
-          if (loadEmbeds)loadEmbeds();
-        }, 2000);
-        return "<div id='" + tourid + "' class='tourwrist-tour-embed direct'></div> <script type='text/javascript' src='http://tourwrist.com/tour_embed.js'></script>";
-      }
-    }),
-
-  new OEmbedProvider("meetup", "rich", ["meetup\\.(com|ps)/.+"], "http://api.meetup.com/oembed"),
-  new OEmbedProvider("ebay", "rich", ["ebay\\.*"], "http://togo.ebay.com/togo/togo.swf?2008013100",
-    {
-      templateRegex: /.*\/([^\/]+)\/(\d{10,13}).*/,
-      embedtag: {
-        width: 355,
-        height: 300,
-        flashvars: "base=http://togo.ebay.com/togo/&lang=en-us&mode=normal&itemid=$2&query=$1"
-      }
-    }),
-  new OEmbedProvider("wikipedia", "rich", ["wikipedia.org/wiki/.+"], "http://$1.wikipedia.org/w/api.php?action=parse&page=$2&format=json&section=0&callback=?", {
-    templateRegex: /.*\/\/([\w]+).*\/wiki\/([^\/]+).*/,
-    templateData: function (data) {
-      if (!data.parse)
-        return false;
-      var text = data.parse['text']['*'].replace(/href="\/wiki/g, 'href="http://en.wikipedia.org/wiki');
-      return  '<div id="content"><h3><a class="nav-link" href="http://en.wikipedia.org/wiki/' + data.parse['displaytitle'] + '">' + data.parse['displaytitle'] + '</a></h3>' + text + '</div>';
-    }
-  }),
-  new OEmbedProvider("imdb", "rich", ["imdb.com/title/.+"], "http://www.imdbapi.com/?i=$1&callback=?",
-    {
-      templateRegex: /.*\/title\/([^\/]+).*/,
-      templateData: function (data) {
-        if (!data.Title)
-          return false;
-        return  '<div id="content"><h3><a class="nav-link" href="http://imdb.com/title/' + data.imdbID + '/">' + data.Title + '</a> (' + data.Year + ')</h3><p>Rating: ' + data.imdbRating + '<br/>Genre: ' + data.Genre + '<br/>Starring: ' + data.Actors + '</p></div>  <div id="view-photo-caption">' + data.Plot + '</div></div>';
-      }
-    }),
-  new OEmbedProvider("livejournal", "rich", ["livejournal.com/"], "http://ljpic.seacrow.com/json/$2$4?jsonp=?"
-    , {
-      templateRegex: /(http:\/\/(((?!users).)+)\.livejournal\.com|.*users\.livejournal\.com\/([^\/]+)).*/,
-      templateData: function (data) {
-        if (!data.username)
-          return false;
-        return  '<div><img src="' + data.image + '" align="left" style="margin-right: 1em;" /><span class="oembedall-ljuser"><a href="http://' + data.username + '.livejournal.com/profile"><img src="http://www.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" /></a><a href="http://' + data.username + '.livejournal.com/">' + data.username + '</a></span><br />' + data.name + '</div>';
-      }
-    }),
-  new OEmbedProvider("circuitbee", "rich", ["circuitbee\\.com/circuit/view/.+"], "http://c.circuitbee.com/build/r/schematic-embed.html?id=$1",
-    {
-      templateRegex: /.*circuit\/view\/(\d+).*/,
-      embedtag: {
-        tag: 'iframe',
-        width: '500',
-        height: '350'
-      }
-    }),
-
-  new OEmbedProvider("googlecalendar", "rich", ["www.google.com/calendar/embed?.+"], "$1",
+  new OEmbedProvider(["www.google.com/calendar/embed?.+"], "$1",
     {templateRegex: /(.*)/, embedtag: {tag: 'iframe', width: '800', height: '600' }}),
-  new OEmbedProvider("jsfiddle", "rich", ["jsfiddle.net/[^/]+/?"], "http://jsfiddle.net/$1/embedded/result,js,resources,html,css/?",
+  new OEmbedProvider(["jsfiddle.net/[^/]+/?"], "https://jsfiddle.net/$1/embedded/result,js,resources,html,css/?",
     {templateRegex: /.*net\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: '300' }}),
-  new OEmbedProvider("jsbin", "rich", ["jsbin.com/.+"], "http://jsbin.com/$1/?",
+  new OEmbedProvider(["jsbin.com/.+"], "https://jsbin.com/$1/?",
     {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: '300' }}),
-  new OEmbedProvider("jotform", "rich", ["form.jotform.co/form/.+"], "$1?",
+  new OEmbedProvider(["form.jotform.co/form/.+"], "$1?",
     {templateRegex: /(.*)/, embedtag: {tag: 'iframe', width: '100%', height: '507' }}),
-  new OEmbedProvider("reelapp", "rich", ["reelapp\\.com/.+"], "http://www.reelapp.com/$1/embed",
+  new OEmbedProvider(["reelapp\\.com/.+"], "https://www.reelapp.com/$1/embed",
     {templateRegex: /.*com\/(\S{6}).*/, embedtag: {tag: 'iframe', width: '400', height: '338'}}),
-  new OEmbedProvider("linkedin", "rich", ["linkedin.com/pub/.+"], "https://www.linkedin.com/cws/member/public_profile?public_profile_url=$1&format=inline&isFramed=true",
+  new OEmbedProvider(["linkedin.com/pub/.+"], "https://www.linkedin.com/cws/member/public_profile?public_profile_url=$1&format=inline&isFramed=true",
     {templateRegex: /(.*)/, embedtag: {tag: 'iframe', width: '368px', height: 'auto'}}),
-  new OEmbedProvider("timetoast", "rich", ["timetoast.com/timelines/[0-9]+"], "http://www.timetoast.com/flash/TimelineViewer.swf?passedTimelines=$1",
-    {templateRegex: /.*timelines\/([0-9]*)/, embedtag: { width: 550, height: 400}, nocache: 1}),
-  new OEmbedProvider("pastebin", "rich", ["pastebin\\.com/[\\S]{8}"], "http://pastebin.com/embed_iframe.php?i=$1",
+  new OEmbedProvider(["pastebin\\.com/[\\S]{8}"], "https://pastebin.com/embed_iframe.php?i=$1",
     {templateRegex: /.*\/(\S{8}).*/, embedtag: {tag: 'iframe', width: '100%', height: 'auto'}}),
-  new OEmbedProvider("mixlr", "rich", ["mixlr.com/.+"], "http://mixlr.com/embed/$1?autoplay=ae",
+  new OEmbedProvider(["mixlr.com/.+"], "https://mixlr.com/embed/$1?autoplay=ae",
     {templateRegex: /.*com\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: 'auto' }}),
   // GitHub is causing issues (rate limiting, "invalid" responses, ...)
-  // new OEmbedProvider("github", "rich", ["gist.github.com/.+"], "https://github.com/api/oembed"),
-  // new OEmbedProvider("github", "rich", ["github.com/[-.\\w@]+/[-.\\w@]+"], "https://api.github.com/repos/$1/$2?callback=?"
+  // new OEmbedProvider(["gist.github.com/.+"], "https://github.com/api/oembed"),
+  // new OEmbedProvider(["github.com/[-.\\w@]+/[-.\\w@]+"], "https://api.github.com/repos/$1/$2"
   //   , {templateRegex: /.*\/([^\/]+)\/([^\/]+).*/,
   //     templateData: function (data) {
   //       if (!data.data.html_url)return false;
@@ -246,58 +132,28 @@ OEmbed.providers = [
   //         + '<p class="oembedall-updated-at">Last updated: ' + data.data.pushed_at + '</p></div></div>';
   //     }
   //   }),
-  new OEmbedProvider("stackoverflow", "rich", ["stackoverflow.com/questions/[\\d]+"], "http://api.stackoverflow.com/1.1/questions/$1?body=true&jsonp=?"
-    , {templateRegex: /.*questions\/([\d]+).*/,
-      templateData: function (data) {
-        if (!data.questions)
-          return false;
-        var q = data.questions[0];
-        var body = $(q.body).text();
-        var out = '<div class="oembedall-stoqembed"><div class="oembedall-statscontainer"><div class="oembedall-statsarrow"></div><div class="oembedall-stats"><div class="oembedall-vote"><div class="oembedall-votes">'
-          + '<span class="oembedall-vote-count-post"><strong>' + (q.up_vote_count - q.down_vote_count) + '</strong></span><div class="oembedall-viewcount">vote(s)</div></div>'
-          + '</div><div class="oembedall-status"><strong>' + q.answer_count + '</strong>answer</div></div><div class="oembedall-views">' + q.view_count + ' view(s)</div></div>'
-          + '<div class="oembedall-summary"><h3><a class="oembedall-question-hyperlink" href="http://stackoverflow.com/questions/' + q.question_id + '/">' + q.title + '</a></h3>'
-          + '<div class="oembedall-excerpt">' + body.substring(0, 100) + '...</div><div class="oembedall-tags">';
-        for (i in q.tags) {
-          out += '<a title="" class="oembedall-post-tag" href="http://stackoverflow.com/questions/tagged/' + q.tags[i] + '">' + q.tags[i] + '</a>';
-        }
-
-        out += '</div><div class="oembedall-fr"><div class="oembedall-user-info"><div class="oembedall-user-gravatar32"><a href="http://stackoverflow.com/users/' + q.owner.user_id + '/' + q.owner.display_name + '">'
-          + '<img width="32" height="32" alt="" src="http://www.gravatar.com/avatar/' + q.owner.email_hash + '?s=32&amp;d=identicon&amp;r=PG"></a></div><div class="oembedall-user-details">'
-          + '<a href="http://stackoverflow.com/users/' + q.owner.user_id + '/' + q.owner.display_name + '">' + q.owner.display_name + '</a><br><span title="reputation score" class="oembedall-reputation-score">'
-          + q.owner.reputation + '</span></div></div></div></div></div>';
-        return out;
-      }
-    }),
-  new OEmbedProvider("wordpress", "rich", ["wordpress\\.com/.+", "blogs\\.cnn\\.com/.+", "techcrunch\\.com/.+", "wp\\.me/.+"], "http://public-api.wordpress.com/oembed/1.0/?for=jquery-oembed-all"),
-  new OEmbedProvider("screenr", "rich", ["screenr\.com"], "http://www.screenr.com/embed/$1",
-    {templateRegex: /.*\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '650', height: 396}}) ,
-  new OEmbedProvider("gigpans", "rich", ["gigapan\\.org/[-.\\w@]+/\\d+"], "http://gigapan.org/gigapans/$1/options/nosnapshots/iframe/flash.html",
-    {templateRegex: /.*\/(\d+)\/?.*/, embedtag: {tag: 'iframe', width: '100%', height: 400 }}),
-  new OEmbedProvider("scribd", "rich", ["scribd\\.com/.+"], "http://www.scribd.com/embeds/$1/content?start_page=1&view_mode=list",
-    {templateRegex: /.*doc\/([^\/]+).*/, embedtag: {tag: 'iframe', width: '100%', height: 600}}),
-  new OEmbedProvider("kickstarter", "rich", ["kickstarter\\.com/projects/.+"], "$1/widget/card.html",
+  new OEmbedProvider(["kickstarter\\.com/projects/.+"], "$1/widget/card.html",
     {templateRegex: /([^\?]+).*/, embedtag: {tag: 'iframe', width: '220', height: 380}}),
-  new OEmbedProvider("slideshare", "rich", ["slideshare\.net"], "//www.slideshare.net/api/oembed/2", {format: 'jsonp'}),
-  new OEmbedProvider("roomsharejp", "rich", ["roomshare\\.jp/(en/)?post/.*"], "http://roomshare.jp/oembed.json"),
-  new OEmbedProvider("coveritlive", "rich", ["coveritlive.com/"], null, {
+  new OEmbedProvider(["slideshare\.net"], "//www.slideshare.net/api/oembed/2", {format: 'jsonp'}),
+  new OEmbedProvider(["roomshare\\.jp/(en/)?post/.*"], "https://roomshare.jp/oembed.json"),
+  new OEmbedProvider(["coveritlive.com/"], null, {
     templateRegex: /(.*)/,
     template: '<iframe src="$1" allowtransparency="true" scrolling="no" width="615px" frameborder="0" height="625px"></iframe>'}),
-  new OEmbedProvider("polldaddy", "rich", ["polldaddy.com/"], null, {
+  new OEmbedProvider(["polldaddy.com/"], null, {
     templateRegex: /(?:https?:\/\/w?w?w?.?polldaddy.com\/poll\/)([0-9]*)\//,
-    template: '<script async type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/p/$1.js"></script>',
+    template: '<script async type="text/javascript" charset="utf-8" src="https://static.polldaddy.com/p/$1.js"></script>',
     nocache: 1
   }),
-  new OEmbedProvider("360io", "rich", ["360\\.io/.+"], "http://360.io/$1", {templateRegex: /.*360\.io\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("bubbli", "rich", ["on\\.bubb\\.li/.+"], "http://on.bubb.li/$1", {templateRegex: /.*on\.bubb\.li\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360}, nocache: 1 }),
-  new OEmbedProvider("cloudup", "rich", ["cloudup\\.com/.+"], "http://cloudup.com/$1?chromeless", {templateRegex: [/.*cloudup\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
-  new OEmbedProvider("codepen", "rich", ["codepen.io/.+"], "http://codepen.io/$1/embed/$2", {templateRegex: [/.*io\/(\w+)\/pen\/(\w+).*/, /.*io\/(\w+)\/full\/(\w+).*/], embedtag: {tag: 'iframe', width: '100%', height: '300'}, nocache: 1 }),
-  new OEmbedProvider("googleviews", "rich", ["(.*maps\\.google\\.com\\/maps\\?).+(output=svembed).+(cbp=(.*)).*"], "https://maps.google.com/maps?layer=c&panoid=$3&ie=UTF8&source=embed&output=svembed&cbp=$5", {templateRegex: /(.*maps\.google\.com\/maps\?).+(panoid=(\w+)&).*(cbp=(.*)).*/, embedtag: {tag: 'iframe', width: 480, height: 360}, nocache: 1 }),
-  new OEmbedProvider("googlemaps", "rich", ["google\\.com\/maps\/place/.+"], "http://maps.google.com/maps?t=m&q=$1&output=embed", {templateRegex: /.*google\.com\/maps\/place\/([\w\+]*)\/.*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("imajize", "rich", ["embed\\.imajize\\.com/.+"], "http://embed.imajize.com/$1", {templateRegex: /.*embed\.imajize\.com\/(.*)/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("mapjam", "rich", ["mapjam\\.com/.+"], "http://www.mapjam.com/$1", {templateRegex: /.*mapjam\.com\/(.*)/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("polar", "rich", ["polarb\\.com/.+"], "http://assets-polarb-com.a.ssl.fastly.net/api/v4/publishers/unknown/embedded_polls/iframe?poll_id=$1", {templateRegex: /.*polarb\.com\/polls\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
-  new OEmbedProvider("ponga", "rich", ["ponga\\.com/.+"], "https://www.ponga.com/embedded?id=$1", {templateRegex: [/.*ponga\.com\/embedded\?id=(\w+).*/, /.*ponga\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1})
+  new OEmbedProvider(["360\\.io/.+"], "https://360.io/$1", {templateRegex: /.*360\.io\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["on\\.bubb\\.li/.+"], "https://on.bubb.li/$1", {templateRegex: /.*on\.bubb\.li\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360}, nocache: 1 }),
+  new OEmbedProvider(["cloudup\\.com/.+"], "https://cloudup.com/$1?chromeless", {templateRegex: [/.*cloudup\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }}),
+  new OEmbedProvider(["codepen.io/.+"], "https://codepen.io/$1/embed/$2", {templateRegex: [/.*io\/(\w+)\/pen\/(\w+).*/, /.*io\/(\w+)\/full\/(\w+).*/], embedtag: {tag: 'iframe', width: '100%', height: '300'}, nocache: 1 }),
+  new OEmbedProvider(["(.*maps\\.google\\.com\\/maps\\?).+(output=svembed).+(cbp=(.*)).*"], "https://maps.google.com/maps?layer=c&panoid=$3&ie=UTF8&source=embed&output=svembed&cbp=$5", {templateRegex: /(.*maps\.google\.com\/maps\?).+(panoid=(\w+)&).*(cbp=(.*)).*/, embedtag: {tag: 'iframe', width: 480, height: 360}, nocache: 1 }),
+  new OEmbedProvider(["google\\.com\/maps\/place/.+"], "https://maps.google.com/maps?t=m&q=$1&output=embed", {templateRegex: /.*google\.com\/maps\/place\/([\w\+]*)\/.*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["embed\\.imajize\\.com/.+"], "https://embed.imajize.com/$1", {templateRegex: /.*embed\.imajize\.com\/(.*)/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["mapjam\\.com/.+"], "https://www.mapjam.com/$1", {templateRegex: /.*mapjam\.com\/(.*)/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["polarb\\.com/.+"], "https://assets-polarb-com.a.ssl.fastly.net/api/v4/publishers/unknown/embedded_polls/iframe?poll_id=$1", {templateRegex: /.*polarb\.com\/polls\/(\w+).*/, embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1}),
+  new OEmbedProvider(["ponga\\.com/.+"], "https://www.ponga.com/embedded?id=$1", {templateRegex: [/.*ponga\.com\/embedded\?id=(\w+).*/, /.*ponga\.com\/(\w+).*/], embedtag: {tag: 'iframe', width: 480, height: 360 }, nocache: 1})
 
 ];
 

--- a/scripts/oembed_sandbox.js
+++ b/scripts/oembed_sandbox.js
@@ -1,2 +1,0 @@
-// This script gets loaded into every sandboxed iframe.
-document.__defineGetter__("cookies", () => "");

--- a/scripts/oembed_sandbox.js
+++ b/scripts/oembed_sandbox.js
@@ -1,0 +1,2 @@
+// This script gets loaded into every sandboxed iframe.
+document.__defineGetter__("cookies", () => "");

--- a/scripts/oembed_sandbox_jsonp.js
+++ b/scripts/oembed_sandbox_jsonp.js
@@ -1,0 +1,39 @@
+// This is the code running inside the oembed jsonp sandbox.
+cb = []; // Used to store the jsonp callbacks.
+(() => {
+  function setup(parent, id, src, timeout) {
+    var el = document.createElement("script");
+    el.type = "text/javascript";
+    el.async = true;
+    src += src.indexOf("?") < 0 ? "?" : "&";    
+    src += `callback=cb[${id}]`;
+    el.src = src;
+
+    var rejectout = setTimeout(() => {
+      cb[id] = null;
+      el.remove();
+      parent.postMessage({ type: "jsonp_reject", id: id, data: "jsonp request failed, timeout!" }, "*");
+    }, timeout);
+
+    cb[id] = data => {
+      clearTimeout(rejectout);
+      if (!cb[id])
+        return;
+      cb[id] = null;
+      el.remove();
+      parent.postMessage({ type: "jsonp_resolve", id: id, data: data }, "*");
+    };
+
+    document.head.appendChild(el);
+  }
+
+  window.addEventListener("message", event => {
+    if (!event.data || event.data.type != "jsonp_request")
+      return;
+    
+    setup(event.source, event.data.id, event.data.src, event.data.timeout);
+  }, false);
+
+})();
+
+

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -428,6 +428,34 @@ function Operator(el)
     if (entry) entry.expanded = false;
   }
 
+  this.commands.embed_expand = function(p, option)
+  {
+    var {name, ref} = r.operator.split_nameref(option);
+
+    var portals = r.operator.lookup_name(name);
+
+    if(portals.length === 0 || !portals[0].json.feed[ref]){
+      return;
+    }
+
+    var entry = portals[0].entries()[ref];
+    if (entry) entry.embed_expanded = true;
+  }
+
+  this.commands.embed_collapse = function(p, option)
+  {
+    var {name, ref} = r.operator.split_nameref(option);
+
+    var portals = r.operator.lookup_name(name);
+
+    if(portals.length === 0 || !portals[0].json.feed[ref]){
+      return;
+    }
+
+    var entry = portals[0].entries()[ref];
+    if (entry) entry.embed_expanded = false;
+  }
+
   this.commands.big = function(p, option)
   {
     if (!p && !option) {


### PR DESCRIPTION
This PR adds some basic oembed support. Embeds load lazily to prevent anything bad(tm) from happening.

The iframes are sandboxed with the following permissions: `allow-popups allow-scripts allow-same-origin`

`allow-same-origin` allows accessing `localStorage` / `cookies`, which is required by some providers.

The oembed provider list is a reduced set, based on the list from https://github.com/nfl/jquery-oembed-all (MIT-licensed, sourced).

![image](https://user-images.githubusercontent.com/1200380/33245936-fdcc117c-d30e-11e7-88c6-25e135e2ea79.png)
![image](https://user-images.githubusercontent.com/1200380/33245938-086863d8-d30f-11e7-9ef1-5b34c0dd673b.png)

Unfortunately some content providers aren't supported yet, though, as they require some additional processing. This PR should provide a good enough baseline, though.

![image](https://user-images.githubusercontent.com/1200380/33245958-5c1417ca-d30f-11e7-9378-5c903d00f6bd.png)
![image](https://user-images.githubusercontent.com/1200380/33245965-6a5d56d4-d30f-11e7-8fb3-7bdd29838714.png)

(At the moment, "Content not supported" is also the generic error message.)