### PR TITLE
Add rdom.js

### DIFF
--- a/rotonde.js
+++ b/rotonde.js
@@ -5,7 +5,7 @@ function Rotonde(client_url)
 
   // SETUP
 
-  this.requirements = {style:["reset","fonts","main"],script:["util","home","portal","feed","entry","operator","oembed","status"]};
+  this.requirements = {style:["reset","fonts","main"],script:["util","rdom","home","portal","feed","entry","operator","oembed","status"]};
   this.includes = {script:[]};
   this.is_owner = false;
 

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -50,44 +50,6 @@ function Entry(data,host)
   }
   this.update(data, host);
 
-  this.element = null;
-  this.element_html = null;
-
-  this.to_element = function(timeline, c, cmin, cmax, offset)
-  {
-    if (c < 0 || c < cmin || cmax <= c) {
-      // Out of bounds - remove if existing, don't add.
-      this.remove_element();
-      return null;
-    }
-
-    var html = this.to_html();
-    if (this.element_html != html) {
-      if (this.element == null) {
-        // Thin wrapper required.
-        this.element = document.createElement('div');
-        this.element.className = 'thin-wrapper';
-      }
-      this.element.innerHTML = html;
-      this.element_html = html;
-      timeline.appendChild(this.element);
-    }
-
-    // The entry is being added to an ordered collection.
-    rdom_move(this.element, c - cmin + offset);
-
-    return this.element;
-  }
-
-  this.remove_element = function() {
-    if (this.element == null)
-      return;
-    // Simpler alternative than elem.parentElement.remove(elem);
-    this.element.remove();
-    this.element = null;
-    this.element_html = null;
-  }
-
   this.to_json = function()
   {
     var quote_json = this.quote ? this.quote.to_json() : this.quote;

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -74,7 +74,7 @@ function Entry(data,host)
     }
 
     // The entry is being added to an ordered collection.
-    move_element(this.element, c - cmin + offset);
+    rdom_move(this.element, c - cmin + offset);
 
     return this.element;
   }
@@ -139,7 +139,7 @@ function Entry(data,host)
       if(this.target[i]){
         var a_attr = "href='" + escape_attr(this.target[i]) + "'";
         if (this.target[i] === r.client_url || this.target[i] === "$rotonde") {
-          a_attr = "style='cursor: pointer;' data-operation='filter:"+r.home.feed.portal_rotonde.json.name+"'";
+          a_attr = "style='cursor: pointer;' data-operation='filter:"+this.host.json.name+"'";
         }
         html += "<a "+a_attr+">" + escape_html(portal_from_hash(this.target[i].toString())) + "</a>";
       }else{

--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -27,7 +27,6 @@ function Entry(data,host)
       else{ this.target = [this.target ? this.target : ""]; }
     }
 
-    this.quote = data.quote;
     if(data.quote && this.target && this.target[0]){
       var icon = this.target[0].replace(/\/$/, "") + "/media/content/icon.svg"
       // set the source's icon for quotes of remotes

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -136,7 +136,7 @@ function Feed(feed_urls)
         clearInterval(r.home.feed.timer);
         r.home.feed.timer = null;
       }
-      this.connections = 0;
+      r.home.feed.connections = 0;
       return;
     }
 
@@ -180,8 +180,12 @@ function Feed(feed_urls)
       break;
     }
 
-    portal.id = this.portals.length;
     this.portals.push(portal);
+
+    for (var id in this.portals) {
+      this.portals[id].id = id;
+    }
+
     var hashes = portal.hashes();
     for (var id in hashes) {
       this.__get_portal_cache__[hashes[id]] = portal;

--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -65,8 +65,6 @@ function Feed(feed_urls)
   this.page_target = null;
   this.page_filter = null;
 
-  this.entries_prev = [];
-
   this.connections = 0;
   // TODO: Move this into a per-user global "configuration" once the Beaker app:// protocol ships.
   this.connections_min = 1;
@@ -289,7 +287,7 @@ function Feed(feed_urls)
 
     if (this.page_target != r.home.feed.target ||
         this.page_filter != r.home.feed.filter) {
-      // Jumping between tabs? Switching filters? Reset!
+      // Jumping between tabs? Switching filters? Jump to first page!
       this.page = 0;
     }
     this.page_target = r.home.feed.target;
@@ -318,6 +316,9 @@ function Feed(feed_urls)
     var cmax = cmin + this.page_size;
     var coffset = 0;
 
+    // Reset culling.
+    rdom_cull(timeline, cmin, cmax, 0);
+
     if (this.page > 0) {
       // Create page_prev_el if missing.
       if (!this.page_prev_el) {
@@ -330,11 +331,22 @@ function Feed(feed_urls)
       }
       // Add 1 to the child offset.
       coffset++;
+      rdom_cull(timeline, cmin, cmax, coffset);
     } else {
       // Remove page_prev_el.
       if (this.page_prev_el) {
         timeline.removeChild(this.page_prev_el);
         this.page_prev_el = null;
+      }
+    }
+
+    
+    if (r.home.pinned_entry) {
+      var entry = r.home.pinned_entry;
+      if (entry.timestamp <= now && entry.is_visible(r.home.feed.filter, r.home.feed.target)) {
+        rdom_add(timeline, entry, 0, entry.to_html.bind(entry));
+        coffset++; // Shift all other entries down by 1 to prevent this pinned entry from moving.
+        rdom_cull(timeline, cmin, cmax, coffset); 
       }
     }
 
@@ -351,36 +363,11 @@ function Feed(feed_urls)
       else if (entry.is_visible("", "whispers"))
         this.whispers++;
 
-      var c = ca;
-      if (!entry || entry.timestamp > now)
-        c = -1;
-      else if (!entry.is_visible(r.home.feed.filter, r.home.feed.target))
-        c = -2;
-      var elem = !entry ? null : entry.to_element(timeline, c, cmin, cmax, coffset);
-      if (elem != null) {
-        entries_now.push(entry);
-      }
-      if (c >= 0)
-        ca++;
-    }
-
-    if (r.home.pinned_entry) {
-        var c = 0;
-        if (!entry || entry.timestamp > now)
-          c = -1;
-        else if (!entry.is_visible(r.home.feed.filter, r.home.feed.target))
-          c = -2;
-        var entry = r.home.pinned_entry.to_element(timeline, c, cmin, cmax, coffset);
-    }
-
-    // Remove any "zombie" entries - removed entries not belonging to any portal.
-    for (id in this.entries_prev) {
-      var entry = this.entries_prev[id];
-      if (entries_now.indexOf(entry) > -1)
+      if (!entry || entry.timestamp > now || !entry.is_visible(r.home.feed.filter, r.home.feed.target))
         continue;
-      entry.remove_element();
+      rdom_add(timeline, entry, ca, entry.to_html.bind(entry));
+      ca++;
     }
-    this.entries_prev = entries_now;
 
     var pages = Math.ceil(ca / this.page_size);
 
@@ -403,8 +390,11 @@ function Feed(feed_urls)
     }
 
     // Reposition paginators.
-    move_element(this.page_prev_el, 0);
-    move_element(this.page_next_el, timeline.childElementCount - 1);
+    rdom_move(this.page_prev_el, 0);
+    rdom_move(this.page_next_el, timeline.childElementCount - 1);
+
+    // Remove zombies.
+    rdom_cleanup(timeline);
 
     r.home.feed.tab_timeline_el.innerHTML = entries.length+" Entries";
     r.home.feed.tab_mentions_el.innerHTML = this.mentions+" Mention"+(this.mentions == 1 ? '' : 's')+"";

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -181,7 +181,6 @@ function Operator(el)
       for (var id in r.home.feed.portals) {
         r.home.feed.portals[id].id = id;
       }
-      portal.badge_remove();
     }
 
     r.home.save();

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -22,9 +22,6 @@ function Portal(url)
 
   this.last_entry = null;
 
-  this.badge_element = null;
-  this.badge_element_html = null;
-
   this.onparse = []; // Contains functions of format json => {...}
   this.fire = function(event) {
     var handlers;
@@ -269,42 +266,6 @@ function Portal(url)
   this.time_offset = function() // days
   {
     return parseInt((Date.now() - this.updated())/1000);
-  }
-
-  this.badge_add = function(special_class, container, c, cmin, cmax, offset)
-  {
-    if (c !== undefined && (c < 0 || c < cmin || cmax <= c)) {
-      // Out of bounds - remove if existing, don't add.
-      this.badge_remove();
-      return null;
-    }
-
-    var html = this.badge(special_class);
-    if (this.badge_element_html != html) {
-      if (this.badge_element == null) {
-        // Thin wrapper required.
-        this.badge_element = document.createElement('div');
-        this.badge_element.className = 'thin-wrapper';
-      }
-      this.badge_element.innerHTML = html;
-      this.badge_element_html = html;
-      container.appendChild(this.badge_element);
-    }
-
-    // If c !== undefined, the badge is being added to an ordered collection.
-    if (c !== undefined)
-      move_element(this.badge_element, c - cmin + offset);
-
-    return this.badge_element;
-  }
-
-  this.badge_remove = function() {
-    if (this.badge_element == null)
-      return;
-    // Simpler alternative than elem.parentElement.remove(elem);
-    this.badge_element.remove();
-    this.badge_element = null;
-    this.badge_element_html = null;
   }
 
   this.badge = function(special_class)

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -97,7 +97,7 @@ function Portal(url)
       return;
     }
 
-    r.home.feed.queue.push.apply(r.home.feed.queue, p.json.sameAs.map((remote_url) => {
+    var remotes = p.json.sameAs.map((remote_url) => {
       return {
         url: remote_url,
         oncreate: function() {
@@ -122,7 +122,10 @@ function Portal(url)
           return false
         }
       }
-    }));
+    });
+    // We try to connect to the remotes before any other portals, as they're of higher priority.
+    remotes.push.apply(remotes, r.home.feed.queue);
+    r.home.feed.queue = remotes;
     r.home.feed.connect();
   }
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -230,13 +230,6 @@ function Portal(url)
     return e;
   }
 
-  this.entries_remove = function() {
-    var entries = this.entries();
-    for (var id in entries) {
-      entries[id].remove_element();
-    }
-  }
-
   this.relationship = function(target = r.home.portal.hashes_set())
   {
     if (this.url === r.client_url) return create_rune("portal", "rotonde");

--- a/scripts/rdom.js
+++ b/scripts/rdom.js
@@ -1,0 +1,227 @@
+// rdom (rotonde dom)
+// Collection of DOM manipulation functions because updating innerHTML every time a single thing changes isn't cool.
+// I guess this is a mini DOM "framework" of some sorts..?
+
+__rdom__ = {
+  contexts: new Map(),
+  context_last_container: null,
+  context_last: null
+}
+
+// Gets a rdom context for the given container element.
+// If no context is present, it creates one and returns it.
+// You shouldn't need to access a rdom context directly.
+// Look inside the method to see what a context holds.
+function rdom_context(container) {
+  if (__rdom__.context_last_container === container) {
+    return __rdom__.context_last;
+  }
+
+  var ctx = __rdom__.contexts.get(container);
+  if (!ctx) {
+    ctx = {
+
+      // Culling setup.
+      cull: false,
+      cullmin: -1,
+      cullmax: -1,
+      culloffset: 0,
+
+      // Elements that were added previously.
+      // This will be checked against "added" on cleanup,
+      // ensuring that anything that shouldn't exist
+      // anymore (zombies) will be removed properly.
+      prev: [],
+      // Elements that were rdom_add-ed.
+      // This will be used and reset in rdom_cleanup.
+      added: [],
+
+      // All current element -> object mappings.
+      references: new Map(),
+      // All current object -> element mappings.
+      elements: new Map(),
+      // All current object -> HTML source mappings.
+      // We avoid comparing against innerHTML as it's slow.
+      htmls: new Map()
+
+    };
+    __rdom__.contexts.set(container, ctx);
+  }
+  __rdom__.context_last_container = container;
+  return __rdom__.context_last = ctx;
+}
+
+// Sets up a culling environment with a given minimum
+// index, maximum index and moving offset.
+function rdom_cull(container, min, max, offset) {
+  var ctx = rdom_context(container);  
+
+  ctx.cull = true;
+  if (min === -1 || max === -1 ||
+      min === undefined || max === undefined) {
+    ctx.cull = false;
+    min = max = -1;
+  }
+  ctx.cullmin = min;
+  ctx.cullmax = max;
+
+  ctx.culloffset = offset !== undefined ? offset : 0;
+}
+
+// Adds or updates an element at the given index.
+// Returns the created / updated wrapper element.
+// For best performance in paginated / culled containers,
+// pass a function as "html." It only gets used if the element
+// is visible.
+// This function needs a reference object so that rdom can find
+// and update existing elements for any given object.
+// For example:
+// When adding entries to the feed, "ref" is the entry being added.
+// Instead of blindly clearing the feed and re-adding all entries,
+// rdom checks if an element for the entry exists and updates it.
+function rdom_add(container, ref, index, html) {
+  var ctx = rdom_context(container);
+
+  if (ctx.cull && (index < ctx.cullmin || ctx.cullmax <= index)) {
+    // Out of bounds - remove if existing, don't add.
+    rdom_remove(container, ref);
+    return null;
+  }
+
+  var el;
+  if (typeof(html) === "object") {
+    // We're (assuming that we're) adding an element directly.
+    el = html;
+    // Replace any existing element with the new one.
+    rdom_remove(container, ref);
+    container.appendChild(el);
+
+  } else {
+    // We're (assuming that we're) given the html contents of the element.
+    if (typeof(html) === "function") {
+      // If we're given a function, call it now.
+      // We don't need its result if the element's culled away.
+      html = html();
+    }
+    // Check if we already added an element for ref.
+    // If so, update it. Otherwise create and add a new element.
+    el = ctx.elements.get(ref);
+    if (!el) {
+      // The element isn't existing yet; create and add it.
+      var range = document.createRange();
+      range.selectNode(container);
+      el = range.createContextualFragment("<span class='rdom-wrapper'>"+html+"</span>").firstElementChild;
+      container.appendChild(el);
+    } else if (ctx.htmls.get(ref) !== html) {
+      // Update the innerHTML of our thin wrapper.
+      el.innerHTML = html;
+    }
+  }
+
+  if (index > -1) {
+    // Move the element to the given index.
+    rdom_move(el, index + ctx.culloffset);
+  }
+
+  // Register the element as "added:" It's not a zombie.
+  ctx.added.push(el);
+  // Register the element as the element of ref.
+  ctx.references.set(el, ref);
+  ctx.elements.set(ref, el);
+  ctx.htmls.set(ref, html);
+
+  return el;
+}
+
+// Removes an object's element in a container.
+// Required to clean up properly. rdom holds references
+// to the element and its reference object; el.remove() isn't enough.
+function rdom_remove(container, ref) {
+  if (!ref)
+    return;
+  var ctx = rdom_context(container);
+  var el = ctx.elements.get(ref);
+  if (!el)
+    return; // The ref object doesn't belong to this context - no element found.
+  // Remove the element and all related object references from the context.
+  ctx.elements.delete(ref);
+  ctx.references.delete(el);
+  ctx.htmls.delete(ref);
+  // Remove the element from the DOM.
+  el.remove();
+}
+
+// Removes an element in a container.
+// Required to clean up properly. rdom holds references
+// to the element and its ref object; el.remove() isn't enough.
+function rdom_remove_el(container, el) {
+  if (!el)
+    return;
+  var ctx = rdom_context(container);
+  var ref = ctx.references.get(el);
+  if (!ref)
+    return; // The element doesn't belong to this context - no ref object found.
+  // Remove the element and all related object references from the context.
+  ctx.references.delete(el);
+  ctx.elements.delete(ref);
+  ctx.htmls.delete(ref);
+  // Remove the element from the DOM.
+  el.remove();
+}
+
+// Removes zombie elements.
+// Call this function after the last rdom_add.
+function rdom_cleanup(container) {
+  var ctx = rdom_context(container);
+  for (id in ctx.prev) {
+    var el = ctx.prev[id];
+    if (ctx.added.indexOf(el) > -1)
+      continue;
+    rdom_remove_el(container, el);
+  }
+  ctx.prev = ctx.added;
+  ctx.added = [];
+}
+
+// Moves an element to a given index.
+function rdom_move(el, index) {
+  if (!el)
+    return;
+  
+  var offset = index;
+  var tmp = el;
+  while (tmp = tmp.previousElementSibling)
+    offset--;
+  
+  // offset == 0: We're fine.
+  if (offset == 0)
+    return;
+  
+  if (offset < 0) {
+    // offset < 0: Element needs to be pushed "left" / "up".
+    // -offset is the "# of elements we expected there not to be",
+    // thus how many places we need to shift to the left.
+    var swap;
+    tmp = el;
+    while ((swap = tmp) && (tmp = tmp.previousElementSibling) && offset < 0)
+      offset++;
+    swap.before(el);
+    
+  } else {
+    // offset > 0: Element needs to be pushed "right" / "down".
+    // offset is the "# of elements we expected before us but weren't there",
+    // thus how many places we need to shift to the right.
+    var swap;
+    tmp = el;
+    while ((swap = tmp) && (tmp = tmp.nextElementSibling) && offset > 0)
+      offset--;
+    swap.after(el);
+  }
+
+}
+
+
+// Don't explicitly make rdom.js require rotonde.
+if (window["r"] && r.confirm) {
+  r.confirm("script", "rdom");
+}

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -5,6 +5,10 @@ function Status()
   this.logo = document.createElement('a'); this.logo.className = "logo"; this.logo.setAttribute("href","https://github.com/Rotonde/rotonde-client");
   this.list = document.createElement('list');
 
+  this.enabled = false;
+
+  this.sorted_portals_prev = [];
+
   this.install = function(target)
   {
     this.el.appendChild(this.h1);
@@ -17,29 +21,35 @@ function Status()
   this.start = function()
   {
     this.h1.textContent = "Rotonde";
-    setInterval(r.status.update,4000)
     r.operator.icon_el.addEventListener('mousedown',r.status.toggle, false);
   }
 
   this.toggle = function()
   {
-    r.el.className = r.el.className == "rotonde" ? "rotonde sidebar" : "rotonde";
+    if (!r.status.enabled) {
+      r.el.classList.add("sidebar");
+    } else {
+      r.el.classList.remove("sidebar");      
+    }
+    r.status.enabled = !r.status.enabled;
   }
 
   this.update = function()
   {
     r.status.h1.innerHTML = "Rotonde <a href='https://github.com/Rotonde/rotonde-client' target='_blank'>"+r.home.portal.json.client_version+"</a>";
+    
+    var sorted_portals = r.home.feed.portals.sort(function(a, b) {
+      return b.updated(false) - a.updated(false);
+    });
 
-    var html = "";
+    for (var id in sorted_portals) {
+      var portal = sorted_portals[id];
+      rdom_add(r.status.list, portal, id,
+        "<ln class='"+(window.location.hash.replace("#","") == portal.json.name ? "filter" : "")+"'><a title='"+(portal.json.client_version ? portal.json.client_version : "Unversioned")+"' data-operation='filter:"+portal.json.name+"' data-validate='true' class='"+(portal.json.client_version && portal.json.client_version == r.home.portal.json.client_version ? "compatible" : "")+"'>"+portal.relationship()+escape_html(portal.json.name)+"</a><span class='time_ago'>"+(portal.updated(false) ? timeSince(portal.updated(false)) : 'XX')+" ago</span></ln>"
+      );
+    }
 
-    for(id in r.home.feed.portals){
-      var portal = r.home.feed.portals[id];
-      html += "<ln class='"+(window.location.hash.replace("#","") == portal.json.name ? "filter" : "")+"'><a title='"+(portal.json.client_version ? portal.json.client_version : "Unversioned")+"' data-operation='filter:"+portal.json.name+"' data-validate='true' class='"+(portal.json.client_version && portal.json.client_version == r.home.portal.json.client_version ? "compatible" : "")+"'>"+portal.relationship()+escape_html(portal.json.name)+"</a><span class='time_ago'>"+(portal.updated(false) ? timeSince(portal.updated(false)) : 'XX')+" ago</span></ln>"
-    }
-    html = "<list>"+html+"</list>";
-    if(r.status.list.innerHTML != html){
-      r.status.list.innerHTML = html;  
-    }
+    rdom_cleanup(r.status.list);
   }
 }
 

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -222,43 +222,6 @@ function create_rune(context, type)
   return `<i class='rune rune-${context} rune-${context}-${type}'></i>`;
 }
 
-// Moves an element to a given index.
-function move_element(el, index) {
-  if (!el)
-    return;
-  
-  var offset = index;
-  var tmp = el;
-  while (tmp = tmp.previousElementSibling)
-    offset--;
-  
-  // offset == 0: We're fine.
-  if (offset == 0)
-    return;
-  
-  if (offset < 0) {
-    // offset < 0: Element needs to be pushed "left" / "up".
-    // -offset is the "# of elements we expected there not to be",
-    // thus how many places we need to shift to the left.
-    var swap;
-    tmp = el;
-    while ((swap = tmp) && (tmp = tmp.previousElementSibling) && offset < 0)
-      offset++;
-    swap.before(el);
-    
-  } else {
-    // offset > 0: Element needs to be pushed "right" / "down".
-    // offset is the "# of elements we expected before us but weren't there",
-    // thus how many places we need to shift to the right.
-    var swap;
-    tmp = el;
-    while ((swap = tmp) && (tmp = tmp.nextElementSibling) && offset > 0)
-      offset--;
-    swap.after(el);
-  }
-
-}
-
 // Fixes an element in place, style-wise.
 // Used f.e. in big picture mode to prevent everything from shifting.
 function position_fixed(...elements)


### PR DESCRIPTION
This PR adds rdom.js, a very lightweight DOM manipulation "framework" (collection of common functions).

Technically, all the functions were already present in rotonde in one form or another. rdom just collects them all and makes them available in a general purpose manner. Also, it makes DOM manipulation less witchcraft-y. For example, we don't need to pass negative values as indices to remove elements anymore: we've got `rdom_remove` and when adding elements in a loop, `rdom_cleanup` removes anything we `continue`d over.

- `rdom_add(container, ref, index, html)`: Adds the `html` of `ref` to `container` at `index`. If an element for `ref` already exists, it updates it and removes it if required.
- `rdom_remove(container, ref)`: Removes the element belonging to `ref` from `container` and frees all references in the container's rdom context.
- `rdom_remove_el(container, el)`: Same as above, but for elements instead.
- `rdom_cleanup(container)`: Removes all zombie elements (f.e. deleted entries, unfollowed portals). Call this after `rdom_add`ing all elements to a container. Technically, it just removes elements that were previously `rdom_add`ed to the container, but aren't anymore.
- `rdom_cull(container, min, max, offset)`: Sets up culling (f.e. pagination) for a given container. All further `rdom_add` calls adhere to the constraints. `offset` is an optional offset (default: 0), useful when something precedes all added items in the container (f.e. "previous page" element, pinned entry).
