### PR TITLE
Fix quote attribution

### DIFF
--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -290,11 +290,13 @@ function Operator(el)
     if (target === r.client_url) {
       target = "$rotonde";
     }
-
+    
+    var targets = [target];
     if (target === r.home.portal.url && quote.target[0]) {
-      target = quote.target[0];
+      // We can quote ourselves, but still target the previous author.
+      targets.push(quote.target[0]);
     }
-    r.operator.send(message, {quote:quote,target:[target],ref:ref,media:quote.media,whisper:quote.whisper});
+    r.operator.send(message, {quote:quote,target:targets,ref:ref,media:quote.media,whisper:quote.whisper});
   }
 
   this.commands.pin = function(p,option)

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -294,7 +294,12 @@ function Operator(el)
     var targets = [target];
     if (target === r.home.portal.url && quote.target[0]) {
       // We can quote ourselves, but still target the previous author.
-      targets.push(quote.target[0]);
+      if (quote.target[0] === r.home.portal.url && quote.target.length > 1) {
+        // We're quoting ourself quoting ourself quoting someone...
+        targets.push(quote.target[1]);
+      } else {
+        targets.push(quote.target[0]);        
+      }
     }
     r.operator.send(message, {quote:quote,target:targets,ref:ref,media:quote.media,whisper:quote.whisper});
   }


### PR DESCRIPTION
Fixes #167.

I accidentally introduced this bug while changing how quoting yourself should preserve the previously quoted target. While it worked (quotes quoting quotes finally properly targetted the previous author), I completely forgot that `target[0]` was being used for quote attribution in threads.

I'm sorry for having introduced the bug earlier.