### PR TITLE
Detect embeds when rendering and allow discoverable: false in portal.json

### DIFF
--- a/links/main.css
+++ b/links/main.css
@@ -73,9 +73,9 @@ body #feed .entry .message .inline { display: inline-block; margin: 6px 4px -6px
 body #feed .entry .hashtag:hover { cursor:pointer; text-decoration: underline; }
 body #feed .entry .media { position: relative; display:block; border-radius:4px; max-width: calc(100% - 30px); max-height: 400px; margin-top:15px; margin-bottom:15px; left: calc(50% - 15px); transform: translateX(-50%); }
 body #feed .entry .media.embed { }
-body #feed .entry .media.embed .media { max-height: 360px; margin-bottom: 20px; }
-body #feed .entry .media.embed iframe.media { width: 100%; }
-body #feed .entry .media.embed iframe.media.sandbox { height: 10000px; /* Limited by max-height */ }
+body #feed .entry .media.embed iframe { max-height: 360px; margin-bottom: 20px; }
+body #feed .entry .media.embed iframe { width: 100%; }
+body #feed .entry .media.embed iframe.sandbox { height: 10000px; /* Limited by max-height */ }
 body #feed .entry .media.embed .expand { margin-top: 0; }
 body #feed .entry .media.embed .expand:hover {  }
 body #feed .entry ::-webkit-media-controls-panel { -webkit-filter: grayscale(); }

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -294,7 +294,8 @@ function Home()
 
     portal.hashes().forEach(r.home.discovered_hashes.add, r.home.discovered_hashes);
 
-    if (portal.is_known(true)) {
+    if (portal.is_known(true) ||
+        (portal.json.discoverable === false /*not null, not undefined, just false*/)) {
       r.home.discover_next_step();
       return;
     }

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -156,8 +156,13 @@ function Operator(el)
       r.home.portal.json.site = r.operator.validate_site(p);
     }
     else if(option == "discoverable"){
-      p = p.toLowerCase().trim();
-      r.home.portal.json.discoverable = p === "" || p === "true" || p === "y" || p === "yes";
+      p = p && p.toLowerCase().trim();
+      if (!p || p === "true" || p === "y" || p === "yes")
+        r.home.portal.json.discoverable = true;
+      else if (p === "false" || p === "n" || p === "no")
+        r.home.portal.json.discoverable = false;
+      else
+        throw new Error("edit:discoverable doesn't support option " + p);
     }
     else{
       r.home.portal.json.feed[option].message = p;

--- a/scripts/operator.js
+++ b/scripts/operator.js
@@ -155,6 +155,10 @@ function Operator(el)
     else if(option == "site"){
       r.home.portal.json.site = r.operator.validate_site(p);
     }
+    else if(option == "discoverable"){
+      p = p.toLowerCase().trim();
+      r.home.portal.json.discoverable = p === "" || p === "true" || p === "y" || p === "yes";
+    }
     else{
       r.home.portal.json.feed[option].message = p;
       r.home.portal.json.feed[option].editstamp = Date.now();


### PR DESCRIPTION
- Embeds are being detected in `entry.to_html`, which only runs when the entry `is_visible` and being rendered to the page.
- Setting `discoverable` to `false` in your portal.json hides it from discovery.
  - This can easily be done via `edit:discoverable true / y / yes / false / f / no`