### PR TITLE
Fix escaping in status.js and topic XSS in entry.js

### DIFF
--- a/scripts/entry.js
+++ b/scripts/entry.js
@@ -101,7 +101,7 @@ function Entry(data,host)
     if (this.host.url === r.client_url || this.host.url === "$rotonde") {
       a_attr = "style='cursor: pointer;' data-operation='filter:"+escape_attr(this.host.json.name)+"'";
     }
-    html += this.topic ? "<a data-operation='filter #"+escape_attr(this.topic.toLowerCase())+"' class='topic'>#"+this.topic+"</a>" : "";
+    html += this.topic ? "<a data-operation='filter #"+escape_attr(this.topic.toLowerCase())+"' class='topic'>#"+escape_html(this.topic)+"</a>" : "";
     html += "<t class='portal'><a "+a_attr+">"+this.host.relationship()+escape_html(this.host.json.name)+"</a> "+this.action()+" ";
 
     for(i in this.target){

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -52,7 +52,7 @@ function Status()
     for (var id in sorted_portals) {
       var portal = sorted_portals[id];
       rdom_add(r.status.list, portal, id,
-        "<ln class='"+(window.location.hash.replace("#","") == portal.json.name ? "filter" : "")+"'><a title='"+(portal.json.client_version ? escape_attr(portal.json.client_version) : "Unversioned")+"' data-operation='filter:"+escape_attr(portal.json.name)+"' data-validate='true' class='"+(portal.json.client_version && portal.json.client_version == r.home.portal.json.client_version ? "compatible" : "")+"'>"+portal.relationship()+escape_html(portal.json.name).substr(0,16)+"</a><span class='time_ago'>"+(portal.updated(false) ? timeSince(portal.updated(false)) : 'XX')+" ago</span></ln>"
+        "<ln class='"+(window.location.hash.replace("#","") == portal.json.name ? "filter" : "")+"'><a title='"+(portal.json.client_version ? escape_attr(portal.json.client_version) : "Unversioned")+"' data-operation='filter:"+escape_attr(portal.json.name)+"' data-validate='true' class='"+(portal.json.client_version && portal.json.client_version == r.home.portal.json.client_version ? "compatible" : "")+"'>"+portal.relationship()+escape_html(portal.json.name.substr(0,16))+"</a><span class='time_ago'>"+(portal.updated(false) ? timeSince(portal.updated(false)) : 'XX')+" ago</span></ln>"
       );
     }
 


### PR DESCRIPTION
1. Substringing the escaped HTML can result in substring cutting off in the middle of an escape sequence.

2. The vulnerabilities in entry.js keep coming >.<

> #<SCRIPT>ALERT("OHNO")</SCRIPT>

![image](https://user-images.githubusercontent.com/1200380/33787773-2232bf52-dc6f-11e7-9555-abe0f93ba046.png)

![image](https://user-images.githubusercontent.com/1200380/33787812-4fb6098e-dc6f-11e7-89ac-9ce6c9b0b9df.png)
