### PR TITLE
Better lazy quote resolves

### DIFF
--- a/scripts/feed.js
+++ b/scripts/feed.js
@@ -323,8 +323,17 @@ This is preferred if you're on a limited data plan. Make sure to {#disable_disco
     setTimeout(function(){window.scrollTo(0, 0);},1000)
   }
 
+  this.__refresh_lazy__ = null;
+  this.refresh_lazy = function(why)
+  {
+    if (this.__refresh_lazy__)
+      clearTimeout(this.__refresh_lazy__);
+    this.__refresh_lazy__ = setTimeout(() => this.refresh("lazy: " + why), 100);
+  }
   this.refresh = async function(why)
   {
+    clearTimeout(this.__refresh_lazy__);
+    this.__refresh_lazy__ = null;
     if(!why) { console.error("unjustified refresh"); }
     console.log("refreshing feed..", "#" + r.home.feed.target, "→"+why);
 

--- a/scripts/portal.js
+++ b/scripts/portal.js
@@ -148,6 +148,8 @@ function Portal(url)
     
     var record;
     try {
+      if (r.db.isSource(p.archive.url))
+        await r.db.unindexArchive(p.archive.url);
       await r.db.indexArchive(p.archive);
       record = await p.get();
     } catch (err) {
@@ -208,7 +210,8 @@ function Portal(url)
 
     var record;
     try {
-      await r.db.indexArchive(p.archive, { watch: false });
+      if (!r.db.isSource(p.archive.url))
+        await r.db.indexArchive(p.archive, { watch: false });
       record = await p.get();
     } catch (err) {
       // console.log('connection failed: ', p.url, err);


### PR DESCRIPTION
"Lazy quote resolves" occur:
- **Rotonde-style quotes (quote in data):** To fetch the `.name` and `.avatar` fields from the profile.
- **Fritter-style replies (threadParent URL in data):** To fetch the thread parent and the above profile data.

This PR simplifies the previous lazy resolving mess and reduces the amount of required feed refreshes by lazily refreshing.

A lazy feed refresh occurs after a given timeout. If another lazy feed refresh occurs before the timeout, the lazy refresh gets delayed. If a normal feed refresh occurs before the timeout, the lazy feed refresh gets canceled.

~~Just make me a member of the Rotonde "organization" please.~~